### PR TITLE
Feature/66

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -12,30 +12,23 @@ Sufia.config do |config|
     "Edit" => "edit"
   }
 
+  # Enable displaying usage statistics in the UI
+  # Defaults to FALSE
+  # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
+  # config.analytics = false
+
   # Specify a Google Analytics tracking ID to gather usage statistics
   # Google Analytics ID
-  if Rails.env.production? or Rails.env.staging?
-
-    # Enable displaying usage statistics in the UI
-    # Defaults to FALSE
-    # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-    config.analytics = true
-
+  if Rails.env.production?
     config.google_analytics_id = 'UA-797260-32'
-
-    # Specify a date you wish to start collecting Google Analytic statistics for.
-    config.analytic_start_date = ''
   end
+
+  # Specify a date you wish to start collecting Google Analytic statistics for.
+  # config.analytic_start_date = DateTime.new(2014,9,10)
 
   # Enables a link to the citations page for a generic_file.
   # Default is false
   # config.citations = false
-
-  # Email recipient of messages sent via the contact form
-  config.contact_email = "digitalscholarship@northwestern.edu"
-
-  # Text prefacing the subject entered in the contact form
-  config.subject_prefix = "Arch (" + Rails.env + ") Contact Form:"
 
   # Enables a link to the citations page for a generic_file.
 # Default is false
@@ -47,7 +40,7 @@ Sufia.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video uncomment this line
-  config.enable_ffmpeg = true
+  # config.enable_ffmpeg = true
 
   # Sufia uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens
@@ -57,7 +50,7 @@ Sufia.config do |config|
   # config.noid_template = ".reeddeeddk"
 
   # Store identifier minter's state in a file for later replayability
-  # config.minter_statefile = '/tmp/minter-state'
+  config.minter_statefile = '/var/www/nufia/minter-storage/minter-state'
 
   # Process for translating Fedora URIs to identifiers and vice versa
   # config.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
@@ -67,7 +60,7 @@ Sufia.config do |config|
   # config.redis_namespace = "sufia"
 
   # Specify the path to the file characterization tool:
-  config.fits_path = "/usr/local/bin/fits-0.8.5/fits.sh"
+  config.fits_path = "/usr/local/bin/fits-0.6.2/fits.sh"
 
   # Specify the path to the file derivatives creation tool:
   # config.libreoffice_path = "soffice"


### PR DESCRIPTION
Fixes #66 

I set the minter-state to be hard coded to `/var/www/nufia/minter-storage/minter-state` and copied the current `minter-state file` over there.  I was kind of waffling back and forth on putting it in /shared and having Capistrano link it in on every deploy vs one hardcoded link.  Ultimately I went this way because there is zero chance of Cap accidentally stepping on it or doing that whole `/releases/DATETIMESTAMP/` mess.  I'm not totally dedicated to this solution though if others want to do it in `/shared` though.

We should just need to deploy after this merge to point it to the copy of the file.