### PR TITLE
hardcode minter-state to point to minter-storage in the nufia directory

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -57,7 +57,7 @@ Sufia.config do |config|
   # config.noid_template = ".reeddeeddk"
 
   # Store identifier minter's state in a file for later replayability
-  # config.minter_statefile = '/tmp/minter-state'
+  config.minter_statefile = '/var/www/nufia/minter-storage/minter-state'
 
   # Process for translating Fedora URIs to identifiers and vice versa
   # config.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id


### PR DESCRIPTION
Fixes #66 

I set the minter-state to be hard coded to `/var/www/nufia/minter-storage/minter-state` and copied the current `minter-state file` over there.  I was kind of waffling back and forth on putting it in `/shared` and having Capistrano link it in on every deploy vs one hardcoded link.  Ultimately I went this way because there is zero chance of Cap accidentally stepping on it or doing that whole `/releases/DATETIMESTAMP/` mess.  I'm not totally dedicated to this solution though if others want to do it in `/shared` though.

We should just need to deploy after this merge to point it to the copy of the file.