### PR TITLE
unlink the derivatives directory and hardcode to it

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :deploy_to, '/var/www/nufia'
 set :linked_files, fetch(:linked_files, []).push('config/analytics.yml', 'config/blacklight.yml', 'config/browse_everything_providers.yml', 'config/database.yml', 'config/fedora.yml', 'config/ldap.yml', 'config/redis.yml', 'config/role_map.yml', 'config/secrets.yml', 'config/sidekiq.yml', 'config/solr.yml')
 
 # Default value for linked_dirs is []
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/derivatives', 'tmp/sockets', 'public/system', 'tmp/uploads')
+set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'tmp/uploads')
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -12,6 +12,9 @@ Sufia.config do |config|
     "Edit" => "edit"
   }
 
+  #Specify the derivatives storage Location
+  config.derivatives_path = '/var/www/nufia/shared/tmp/derivatives/'
+
   # Specify a Google Analytics tracking ID to gather usage statistics
   # Google Analytics ID
   if Rails.env.production? or Rails.env.staging?


### PR DESCRIPTION
Fixes #74 

Since we already have a populated `derivatives` directory in `shared/tmp` I'm voting to just to leave it there for now and link directly to it via `/var/www/nufia/shared/derivatives`.  If we do this we also don't need to link the `derivatives` directory over every time we deploy so I removed that from deploy.rb.  Our other option would be to copy the entirely directory to somewhere such as `/var/www/nufia/derivatives`, copy everything over and use that.  Although I believe that would the services that already know of `/var/www/nufia/shared/derivatives`.