### PR TITLE
Fix links on mobile nav

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -12,10 +12,10 @@
                 <a href="#mobile-nav" class="mobile-link mobile-nav-link"><span class="hide-label">Menu</span></a>
                 <nav id="mobile-nav">
                     <ul aria-label="main menu" tabindex="-1">
-                        <li class="active"><a href="#">Home</a></li>
-                        <li class="active"><a href="#">Catalog</a></li>
-                        <li class="active"><a href="#">About</a></li>
-                        <li class="active"><a href="#">Contact</a></li>
+                        <li class="active"><a href="<%= main_app.search_catalog_path %>">Browse</a></li>
+                        <li class="active"><a href="<%= sufia.about_path %>">About</a></li>
+                        <li class="active"><a href="<%= main_app.help_path %>">Help</a></li>
+                        <li class="active"><a href="<%= sufia.contact_path %>">Contact</a></li>
                     </ul>
                     <div id="mobile-nav-bottom">
                         <%= render partial: '/toolbar_mobile' %>


### PR DESCRIPTION
Fixes #79 

Mobile navigation links currently don't go anywhere. Changed to match regular nav links.