### PR TITLE
use dirty inline css to force display:inline-block; for the drop lis,…

### DIFF
--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <% if can? :manage, :all %>
-    <li class="drop">
+    <li class="drop" style="display:inline-block;">
       <%= link_to sufia.admin_stats_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
         <span class="fa fa-gear"></span> Admin <span class="caret"></span>
       <% end %>
@@ -18,7 +18,7 @@
     </li>
   <% end %>
 
-  <li class="drop">
+  <li class="drop" style="display:inline-block;">
     <%= link_to sufia.dashboard_index_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
       <span class="fa fa-tachometer"></span> Dashboard <span class="caret"></span>
     <% end %>
@@ -39,7 +39,7 @@
   </li>
 
   <% if can? :create, GenericWork %>
-    <li class="drop">
+    <li class="drop" style="display:inline-block;">
       <%= link_to sufia.dashboard_works_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
         <span class="fa fa-cube"></span> Works <span class="caret"></span>
       <% end %>
@@ -52,7 +52,7 @@
   <% end %>
 
   <% if can?(:create, Collection) %>
-    <li class="drop">
+    <li class="drop" style="display:inline-block;">
       <%= link_to sufia.dashboard_collections_path, role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
         <span class="fa fa-cubes"></span> Collections <span class="caret"></span>
       <% end %>


### PR DESCRIPTION
Fixes #84 

After some digging, for this to work on Windows (in any browser) we need a style of `display:inline-block;` on the `<li class="drop">` element.  I tried applied this in the `nul-template` css to the .drop class and then in `nufia.scss` (using a new class and making it `<li class="drop newclass>` but for some reason something in jquery seemed to stomp on that.  The only way I can get the class to apply and not be overridden is in the inline style.

If anyone can see how to apply this non inline they should feel free to suggest it or update this branch prior to merging this PR.