### PR TITLE
Feature#167 update nufonts links headlines

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -38,6 +38,7 @@
 @import "nul-template/sections/footer";
 
 // add your own modules below
+@import "bootstrap-overrides/main";
 @import "sufia";
 @import "nufia";
 

--- a/app/assets/stylesheets/bootstrap-overrides/_main.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_main.scss
@@ -1,0 +1,2 @@
+@import "variables";
+@import "type";

--- a/app/assets/stylesheets/bootstrap-overrides/_type.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_type.scss
@@ -1,0 +1,10 @@
+h1, h2, h3, h4, h5 {
+  line-height: 1.2em;
+}
+h2 {
+  font-family: $CamptonBold;
+}
+h3 {
+  font-family: $AkkuratProRegular;
+  color: $rich-black-50;
+}

--- a/app/assets/stylesheets/bootstrap-overrides/_variables.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_variables.scss
@@ -1,0 +1,27 @@
+/**
+ * Define new bootstrap variables before we @import bootstrap.
+ * Variable name reference here => http://getbootstrap.com/customize/#less-variables
+ */
+
+/**********
+ * Colors *
+ **********/
+
+/***************
+ * Scaffolding *
+ ***************/
+$link-color: $nu-purple;
+$link-hover-color: $nu-purple;
+$text-color: $rich-black-80;
+
+/**************
+ * Typography *
+ **************/
+$font-family-sans-serif: $AkkuratProRegular;
+$font-size-base: 16px;
+$font-size-h1: 46px;
+$font-size-h2: 34px;
+$font-size-h3: 26px;
+$font-size-h4: 21px;
+$headings-color: $nu-purple;
+$headings-font-family: $CamptonBook;

--- a/app/assets/stylesheets/nufia.scss
+++ b/app/assets/stylesheets/nufia.scss
@@ -1,3 +1,6 @@
+// Override gem Bootstrap styles
+@import "bootstrap-overrides/main";
+
 // Override and/or extend /nul-template styles
 // base
 @import "nufia/base/variables";

--- a/app/assets/stylesheets/nufia/base/_buttons.scss
+++ b/app/assets/stylesheets/nufia/base/_buttons.scss
@@ -1,3 +1,4 @@
+// TODO: Remove this now?
 button {
   &.btn-primary {
     background-color: $nu-purple-60;

--- a/app/assets/stylesheets/nufia/sufia/_footer.scss
+++ b/app/assets/stylesheets/nufia/sufia/_footer.scss
@@ -1,0 +1,3 @@
+body {
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/nufia/sufia/_main.scss
+++ b/app/assets/stylesheets/nufia/sufia/_main.scss
@@ -1,2 +1,9 @@
+/**
+ * The files referenced below mimic Sufia's sass partials structure.
+ * Some seem odd, like including a 'body' style in _footer.scss,
+ * however the structure is intentional on our end for clarity.
+ */
+
 @import "styles";
+@import "footer";
 @import "home-page";

--- a/app/assets/stylesheets/nufia/sufia/_styles.scss
+++ b/app/assets/stylesheets/nufia/sufia/_styles.scss
@@ -1,5 +1,9 @@
 #content-wrapper {
+  padding: 20px 0 30px;
   header {
     background-color: white;
+  }
+  a {
+    font-family: $AkkuratProBold;
   }
 }

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -3,7 +3,6 @@
  *= require select2
  *= require_self
 */
-
 @import "bootstrap-sprockets";
 @import 'bootstrap';
 @import 'blacklight/blacklight';


### PR DESCRIPTION
Fixes #167 #168 #172 

Updates Arch to use NU's font, headline style and primary link styles.  Also removed an extra bottom margin.

Adjusted some sass import order, to declare custom variables before Rails compiles Bootstrap where possible (minimally invasive fixes).  Some Bootstrap styles must still be explicitly overwritten, but trying where possible, not to re-dupe code.