### PR TITLE
Pass the right payload_concern parameter to the batch upload form

### DIFF
--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -44,7 +44,8 @@
       <ul>
         <li><%= link_to 'My Works', sufia.dashboard_works_path %></li>
         <li><%= link_to 'New Work', main_app.new_curation_concerns_generic_work_path %></li>
-        <li><%= link_to 'Batch Create', sufia.new_batch_upload_path %></li>
+        <li><%= link_to t("sufia.toolbar.works.batch"),
+                        sufia.new_batch_upload_path(payload_concern: create_work_presenter.first_model) %></li>
       </ul>
     </li>
   <% end %>

--- a/app/views/_toolbar_mobile.html.erb
+++ b/app/views/_toolbar_mobile.html.erb
@@ -41,7 +41,8 @@
     <li><i class="fa fa-cube"></i>Works</li>
     <li><%= link_to 'My Works', sufia.dashboard_works_path %></li>
     <li><%= link_to 'New Work', main_app.new_curation_concerns_generic_work_path %></li>
-    <li><%= link_to 'Batch Create', sufia.new_batch_upload_path %></li>
+    <li><%= link_to t("sufia.toolbar.works.batch"),
+                    sufia.new_batch_upload_path(payload_concern: create_work_presenter.first_model) %></li>
   <% end %>
 
   <% if can?(:create, Collection) %>


### PR DESCRIPTION
Fixes #177  ; refs #160 

This change allows batch upload functionality to work in the 7.3 upgrade.

## Documentation
More work needs to be done to clean up some of the view customizations for 7.3 to work completely. Issues forthcoming.