### PR TITLE
Update alert message background colors from Bootstrap colors to NU al…

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides/_alerts.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_alerts.scss
@@ -1,0 +1,5 @@
+.alert-dismissable {
+    .close {
+      opacity: 1;
+    }
+}

--- a/app/assets/stylesheets/bootstrap-overrides/_main.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_main.scss
@@ -2,3 +2,4 @@
 @import "grid";
 @import "type";
 @import "buttons";
+@import "alerts";

--- a/app/assets/stylesheets/bootstrap-overrides/_variables.scss
+++ b/app/assets/stylesheets/bootstrap-overrides/_variables.scss
@@ -26,7 +26,25 @@ $font-size-h4: 21px;
 $headings-color: $nu-purple;
 $headings-font-family: $CamptonBook;
 
+/**************
+ * Components *
+ **************/
+$border-radius-base: 0;
+
 /***********
  * Buttons *
  ***********/
 $btn-primary-bg: $nu-purple;
+
+/**************************
+ * Form states and alerts *
+ **************************/
+$state-success-bg: $nu-purple-10;
+$state-warning-bg: $nu-purple-10;
+$state-info-bg: $nu-purple-10;
+$state-danger-bg: $blood-orange;
+
+/*********
+ * Close *
+ *********/
+$close-text-shadow: 0;

--- a/app/assets/stylesheets/nufia/sufia/_styles.scss
+++ b/app/assets/stylesheets/nufia/sufia/_styles.scss
@@ -20,3 +20,10 @@
     }
   }
 }
+
+.alert {
+  margin: 20px 0;
+  background-color: $nu-purple-10;
+  border-color: $nu-purple-10;
+  color: inherit;
+}

--- a/app/views/layouts/sufia.html.erb
+++ b/app/views/layouts/sufia.html.erb
@@ -10,7 +10,9 @@
     <a href="#skip_to_content" class="sr-only">Skip to Content</a>
     <%= render partial: '/masthead' %>
     <%= content_for(:navbar) %>
-    <%= render partial: '/flash_msg' %>
+    <div class="contain-1120">
+      <%= render partial: '/flash_msg' %>
+    </div>
     <%= content_for(:precontainer_content) %>
     <div id="page" class="<%= content_for?(:container_class) ? yield(:container_class) : 'container' %>" role="main">
       <div class="row">

--- a/app/views/sufia/homepage/index.html.erb
+++ b/app/views/sufia/homepage/index.html.erb
@@ -1,3 +1,5 @@
+<!-- File Overwrite: Overwrites gem file 'sufia-7.3.0/app/views/sufia/homepage/index.html.erb' -->
+
 <% provide :page_title, application_name %>
 <%= render 'announcement' %>
 <div id="home-header" class="contain-1440 row">


### PR DESCRIPTION
Fixes #183 

Update alerts (ie. Successfully logged in...) width & styling

Previously, alerts were hanging outside of the primary page container.  Wrapped their display (logging in and out) in NU template container, plus updated the background coloring to look less Bootstrap and more NU.
