### PR TITLE
using a static page for now to override sufia page

### DIFF
--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -1,0 +1,85 @@
+<h1>Help</h1>
+<p>Arch is supported by <a href="http://www.library.northwestern.edu/about/contact/staff-directory.html#Digital_Scholarship_Services">Digital Scholarship Services</a> of Northwestern University Libraries. If you need to report a problem or request assistance, please use the <a href="https://arch.library.northwestern.edu/contact">Contact Form</a> and a librarian will get back to you.</p>
+<h2>How to Deposit Your Research</h2>
+<p>Step One: Sign into Your Account</p>
+<ul>
+  <li>Use Your Northwestern University NetID to sign into your account</li>
+</ul>
+
+<p>Step Two: Describe Your Research</p>
+<ul>
+  <li>Click on “Create Work”</li>
+  <li>Fill in the required fields</li>
+  <li>You are required to select the rights associated with your research. The standard selection is “All Rights Reserved” but you are welcome to choose a Creative Commons Licenses as well.</li>
+  <li>To make your research easier to find, click on the Additional Fields button to further describe your research</li>
+</ul>
+
+<p>Step Three: Upload Your Research</p>
+<ul>
+  <li>Click on the Files tab above the metadata fields</li>
+  <li>Add the file you would like to deposit. Most deposits are one file for each work, like a journal article or dataset; however, you are free to upload multiple files for the same work </li>
+</ul>
+
+<p>Step Four: Save to the Repository</p>
+<ul>
+  <li>On the right side of the screen, choose the level of online visibility for your work:</li>
+  <ul>
+    <li>Public: Your work is publicly available online</li>
+    <li>Your Institution: Your work is only available to Northwestern University affiliates</li>
+    <li>Embargo: Your work will be restricted for a limited amount of time, usually 1 or 2 years</li>
+    <li>Lease: Your work will be available for a limited amount of time</li>
+    <li>Private: Your work will be preserved, but available only to you, Arch administrators, and any individuals with whom you choose to share the work</li>
+  </ul>
+  <li>Read and accept the <a href="https://arch.library.northwestern.edu/agreement">Deposit Agreement</a></li>
+  <li>Click “Save”</li>
+</ul> 
+
+<h2>Frequently Asked Questions</h2>
+ 
+<h3>Who can use Arch?</h3>
+<p>Anyone can search and download files from Arch. In order to deposit files, you must be a Northwestern University faculty, student, researcher or staff member with a current Northwestern University network account (NetID) and password. </p>
+ 
+<h3>Does it cost anything?</h3>
+<p>Arch is a service provided by the Libraries to the Northwestern community free of charge, and funded by Northwestern University. </p>
+ 
+<h3>What is Open Access?</h3>
+<p>Arch is an open access repository designed to make scholarly research freely accessible on the public internet and preserved using digital preservation standards and technologies. According to the Scholarly Publishing and Academic Resources Coalition (to which Northwestern University is a member), “Open Access is the free, immediate, online availability of research articles coupled with the rights to use these articles fully in the digital environment” (<a href="http://sparcopen.org/open-access/">SPARC</a>). For more information about the open access movement, PHD Comics created this “<a href="https://www.youtube.com/watch?v=L5rVH1KGBCY">Open Access Explained</a>” video.</p>
+ 
+<h3>I’m interested in depositing my research publications to make them open access. How do I know what I can upload?</h3>
+<p>This depends on the copyright and permissions policies of the publisher, as well as your publishing agreement with them. Most journal publishers post their open access policies on their websites or include them in their publishing agreements. Book publishers may need to be contacted directly about this. <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> offers summaries of permissions that are normall given as part of each publisher's copyright transfer agreement, though the terms of your particular agreement may differ.
+Typically, scholarly publishers allow researchers to upload the version before it was published, i.e., the pre-print, or the version of it after it was submitted and peer-reviewed, i.e., the post-print. Open access publishers generally allow final PDF versions to be uploaded to institutional repositories.</p>
+<p>If you have given the publisher exclusive rights to all versions of the publication, they may indeed prohibit your ability to post it elsewhere. However, publishers do sometimes change their policies due to public demand, so it may be worthwhile to contact them and make a case for open access. We may be able to help you find the right people to contact about this issue. If you need help determining whether or not you have the rights to upload your research to Arch, please <a href="https://arch.library.northwestern.edu/contact">Contact Us</a>.</p>
+ 
+<h3>Does all my research on Arch need to be open access?</h3>
+<p>No. While all work deposited to Arch will be preserved, you have the option to limit the visibility of each item you deposit.</p>
+<ul> 
+  <li>Public: Your work is publicly available online</li>
+  <li>Your Institution: Your work is only available to Northwestern University affiliates</li>
+  <li>Embargo: Your work will be restricted for a limited amount of time, usually 1 or 2 years</li>
+  <li>Lease: Your work will be available for a limited amount of time</li>
+  <li>Private: Your work will be preserved, but available only to you, Arch administrators, and any individuals with whom you choose to share the work</li>
+</ul> 
+
+<h3>What happens to my files after I leave Northwestern?</h3>
+<p>Content uploaded to Arch are subject to the Libraries’ <a href="http://www.library.northwestern.edu/about/administration/policies/digital-preservation-policy.html">Digital Preservation Policy</a>. After you leave Northwestern University, the files remain in Arch and continue to be discoverable, accessible, and citable. If you have any questions or concerns about your files after you have left the University, you may submit them via our <a href="https://arch.library.northwestern.edu/contact">Contact Form</a>.</p>
+  
+<h3>How large can a file be to be uploaded to Arch?</h3>
+<p>Arch can accommodate single file sizes up to 500 MB. The larger the file, the more likely a server timeout will occur. We recommend you compress CSV or TSV files before uploading.</p>
+<p>If you are experiencing problems, please <a href="https://arch.library.northwestern.edu/contact">Contact Us</a> and we will help you.</p>
+ 
+<h3>What if I would like to upload a file larger than 500 MB?</h3>
+<p><a href="https://arch.library.northwestern.edu/contact">Contact Us</a> and we will help you.<p>
+ 
+<h3>Are there limits to the number of files I can upload?</h3>
+<p>At present, no. You may upload as many files you have the rights to.</p>
+ 
+<h3>Can I use Arch for managing my data, to comply with data management plan (DMP) requirements?</h3>
+<p>Yes. Unless a funder requires you to deposit your data in a specific repository, Arch can accomodate data sharing and preservation requirements. We also suggest you consult these resources for data management:</p>
+<ul>
+  <li><a href="http://libguides.northwestern.edu/datamanagement">Data Management Research Guide</a></li>
+  <li><a href="https://dmptool.org/">Data Management Planning Tool</a></li>
+</ul>
+  
+<h3>What is Creative Commons Licensing?</h3>
+<p>Creative Commons licenses allow the public to use and share copyrighted works with proper attribution to the copyright holder. While the Fair Use doctrine offers users a defense against charges of copyright infringement, Creative Commons licenses are standard permission statements by the copyright holder to allow different levels of use, such as downloading, sharing publicly, and adapting. Arch provides several options for assigning your research materials a Creative Commons license. You can read more about the differences between these licenses on the <a href="https://creativecommons.org/licenses/">Creative Commons website</a>, or you can <a href="https://arch.library.northwestern.edu/contact">Contact Us</a> for assistance.</p>
+


### PR DESCRIPTION
Fixes #197 

There's a static page in the Sufia gem that's just a placeholder, but gets resolved when somebody goes to /help . 

So for right now it's easiest to just override it and put in our own static content. In Hyrax we wont' have this issue