### PR TITLE
Fix admin floating sidebar

### DIFF
--- a/app/assets/stylesheets/hyrax/admin.scss
+++ b/app/assets/stylesheets/hyrax/admin.scss
@@ -1,0 +1,3 @@
+body {
+  padding-top: 0;
+}


### PR DESCRIPTION
Fixes #214  ; 

Fixes floating Hyrax admin sidebar.

The Hyrax gem's Sass structure has an 'admin.scss' stylesheet, which it sets up as it's own compiled admin.css file at run-time in the app.  Not sure why, but this makes it impossible to override this admin style file in our Arch project's application.css.scss, so I just duped the file structure and created 'stylesheets/hyrax/admin.scss in our app.
