### PR TITLE
Use string conversion in ldap department parsing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,8 +38,8 @@ class User < ActiveRecord::Base
         self.department = attrs[:department].first
       else
         self.display_name = attrs[:displayname].first
-        # nuPosition1 is formmatted: title$$department$$address$$$mailcode
-        self.department = attrs[:nuPosition1].first.split("$$").second
+        # nuPosition1 is formatted: title$$department$$address$$$mailcode
+        self.department = attrs[:nuPosition1].first.to_s.split("$$").second
       end
     end
   end


### PR DESCRIPTION
Fixes #234 

Current behavior when `attrs[:nuPosition1]` returns `[]`:
```
attrs[:nuPosition1].first.split("$$").second
NoMethodError: undefined method `split' for nil:NilClass
```
This change protects against that error by adding string conversion to the method chain.

```attrs[:nuPosition1].first.to_s.split("$$").second```