### PR TITLE
Set browse-everything gem to github master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'devise_ldap_authenticatable', '~> 0.8.5'
 gem 'solr_wrapper', '>= 0.3'
 #end
 
+gem 'browse-everything', github: 'samvera/browse-everything', branch: 'master'
 gem 'rsolr', '~> 1.0'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,23 @@
+GIT
+  remote: git://github.com/samvera/browse-everything.git
+  revision: 38b49c223d5ba95e4d87a27724a22417e3a6d65c
+  branch: master
+  specs:
+    browse-everything (0.14.1)
+      addressable (~> 2.5)
+      aws-sdk
+      bootstrap-sass
+      dropbox-sdk (>= 1.6.2)
+      font-awesome-rails
+      google-api-client (~> 0.9)
+      google_drive
+      httparty
+      rails (>= 3.1)
+      ruby-box
+      sass-rails
+      signet
+      skydrive
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -544,20 +564,6 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
-    browse-everything (0.14.1)
-      addressable (~> 2.5)
-      aws-sdk
-      bootstrap-sass
-      dropbox-sdk (>= 1.6.2)
-      font-awesome-rails
-      google-api-client (~> 0.9)
-      google_drive
-      httparty
-      rails (>= 3.1)
-      ruby-box
-      sass-rails
-      signet
-      skydrive
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (1.17.0)
@@ -1189,6 +1195,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  browse-everything!
   byebug
   capistrano (~> 3.1)
   capistrano-bundler


### PR DESCRIPTION
Refs: #314 

Tracks the latest update to `browse-everything` which uses the `content_length` header to set the `file_length` param. Now the ImportUrlJob should use the `stream_body` option by default.