### PR TITLE
fix .raw file downloads filename and extensions

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,0 +1,39 @@
+
+<div class="btn-group">
+
+  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+  <% if can?(:edit, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
+        { title: "Edit #{file_set}" } %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+        { title: "Display previous versions" } %>
+    </li>
+  <% end %>
+
+  <% if can?(:destroy, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Delete', polymorphic_path([main_app, file_set]),
+        method: :delete, title: "Delete #{file_set}",
+        data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"} %>
+    </li>
+  <% end %>
+
+  <% if can?(:download, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Download', hyrax.download_path(file_set, filename: file_set.label),
+        title: "Download #{file_set.to_s.inspect}", download: file_set.to_s %>
+    </li>
+  <% end %>
+
+  </ul>
+</div>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,0 +1,10 @@
+<div class="no-preview">
+  <%= t('hyrax.works.show.no_preview') %>
+  <% if Hyrax.config.display_media_download_link? %>
+    <p/><%= link_to t('hyrax.file_set.show.download'),
+      hyrax.download_path(file_set, filename: file_set.label),
+      id: "file_download",
+      data: { label: file_set.id },
+      download: file_set.to_s %>
+  <% end %>
+</div>


### PR DESCRIPTION
Fixes https://github.com/nulib/repodev_planning_and_docs/issues/77 
Fixes #318 

 - Override the Hyrax views to send the `filename` parameter so that the (Box uploaded) downloaded file has original filename and extension
 - add the download html attribute and remove target=_new or _blank so that downloaded file (default files only) do not open in new windows. 
