### PR TITLE
override downloaded file name and behavior for all file types

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,0 +1,6 @@
+  <%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
+  <audio controls="controls" class="audiojs" preload="auto">
+    <source src="<%= hyrax.download_path(file_set, file: 'ogg', filename: file_set.label)) %>" type="audio/ogg" />
+    <source src="<%= hyrax.download_path(file_set, file: 'mp3', filename: file_set.label)) %>" type="audio/mpeg" />
+    Your browser does not support the audio tag.
+  </audio>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,3 +1,4 @@
+<%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
 <div class="no-preview">
   <%= t('hyrax.works.show.no_preview') %>
   <% if Hyrax.config.display_media_download_link? %>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,0 +1,25 @@
+<%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to hyrax.download_path(file_set, filename: file_set.label),
+                  data: { turbolinks: false },
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id },
+                  class: "btn btn-default" do %>
+          <%= t('hyrax.file_set.show.downloadable_content.image_link') %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,0 +1,25 @@
+<%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to hyrax.download_path(file_set, filename: file_set.label),
+                  data: { turbolinks: false },
+                  filename: file_set.label,
+                  id: "file_download",
+                  data: { label: file_set.id },
+                  class: "btn btn-default" do %>
+          <%= t('hyrax.file_set.show.downloadable_content.office_link') %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,25 @@
+<%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
+<% if Hyrax.config.display_media_download_link? %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to hyrax.download_path(file_set, filename: file_set.label),
+                  data: { turbolinks: false },
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id },
+                  class: "btn btn-default" do %>
+          <%= t('hyrax.file_set.show.downloadable_content.pdf_link') %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,0 +1,6 @@
+<%# overriding view from Hyrax in order to pass :filename param for Box downloads %>
+<video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+  <source src="<%= hyrax.download_path(file_set, file: 'webm', filename: file_set.label)) %>" type="video/webm" />
+  <source src="<%= hyrax.download_path(file_set, file: 'mp4', filename: file_set.label)) %>" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>


### PR DESCRIPTION
Fixes #318

There are different view partials for handling the download behavior of different file types. Overriding all of them so that (Box uploaded) downloads will be named with original filename + extension. 
