### PR TITLE
Adds cap task arch:env to print variables

### DIFF
--- a/lib/capistrano/tasks/env.rake
+++ b/lib/capistrano/tasks/env.rake
@@ -1,0 +1,8 @@
+namespace :arch do
+  desc 'Print environment variables'
+  task :env do
+    on roles(:all) do
+      execute "env"
+    end
+  end
+end


### PR DESCRIPTION
Will make debugging easier to see what variables cap has access to.

Example use:

```
KDIDRICKSON-MAC:arch ksd927$ bundle exec cap staging arch:env
00:00 arch:env
      01 env
      01 RBENV_VERSION=2.3.0
      01 XDG_SESSION_ID=2683
      01 SHELL=/bin/bash
      01 SSH_CLIENT=129.105.19.199 54763 22
      01 USER=vagrant
      01 LD_LIBRARY_PATH=/usr/local/bin/fits-1.0.5/tools/mediainfo/linux
      01 RBENV_ROOT=/home/vagrant/.rbenv
      01 SSH_AUTH_SOCK=/tmp/ssh-atUNyI9Cuv/agent.23337
      01 MAIL=/var/mail/vagrant
      01 PATH=/usr/local/bin:/usr/bin:/opt/puppetlabs/bin
      01 PWD=/home/vagrant
      01 LANG=en_US.UTF-8
      01 SHLVL=1
      01 HOME=/home/vagrant
      01 LOGNAME=vagrant
      01 SSH_CONNECTION=129.105.19.199 54763 129.105.20.2 22
      01 LESSOPEN=||/usr/bin/lesspipe.sh %s
      01 XDG_RUNTIME_DIR=/run/user/1000
      01 _=/usr/bin/env
    ✔ 01 vagrant@nufiaweb-s.library.northwestern.edu 0.057s
```