### PR TITLE
#300 - Hide relationships table when none exist for work or collection

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,38 @@
+<% provide :page_title, @presenter.page_title %>
+<div itemscope itemtype="http://schema.org/CreativeWork" class="row">
+  <div class="col-xs-12">
+    <header>
+      <%= render 'work_title', presenter: @presenter %>
+    </header>
+
+    <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
+  </div>
+  <div class="col-sm-8">
+    <%= render 'work_description', presenter: @presenter %>
+
+    <%# Hide Hyrax's "Relationships" table if no relationships exist %>
+    <%# https://github.com/nulib/institutional-repository/issues/300 %>
+    <% if (!@presenter.member_of_collection_presenters.blank?) %>
+      <%= render 'relationships', presenter: @presenter %>
+    <% end %>
+
+    <%= render 'metadata', presenter: @presenter %>
+  </div>
+  <div class="col-sm-4">
+    <%= render "show_actions", presenter: @presenter %>
+    <%= t('.last_modified', value: @presenter.date_modified) %>
+    <%= render 'representative_media', presenter: @presenter %>
+    <%= render 'social_media' %>
+    <%= render 'citations', presenter: @presenter %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= render 'items', presenter: @presenter %>
+    <%= render 'workflow_actions_widget', presenter: @presenter %>
+    <%# TODO: we may consider adding these partials in the future %>
+    <%#= render 'sharing_with', presenter: @presenter %>
+    <%#= render 'user_activity', presenter: @presenter %>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #300 

I'm pretty sure I found where Hyrax temporarily stores the value of whether a Work or Collection has Relationships or not.   Lines #13-17 below.  The file itself is overriding a Hyrax view.