### PR TITLE
Arch constrain work title in column view so it breaks to next line

### DIFF
--- a/app/assets/stylesheets/arch/base/_typography.scss
+++ b/app/assets/stylesheets/arch/base/_typography.scss
@@ -13,3 +13,7 @@
 .collection-icon-search {
   color: $rich-black-20;
 }
+
+#page h1 {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #296 
Update CSS to break very long titles to the next line.