### PR TITLE
get dev environment uploads working using default config.upload_path

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,5 @@
 active_job:
   queue_adapter: inline
 aws:
-  buckets:
-    upload: arch-uploads
   queues:
     default: arch-queue


### PR DESCRIPTION
Fixes https://github.com/nulib/next-generation-repository/issues/545

* Note that prod still needs to be configured, but this gets us working locally.