### PR TITLE
[WIP] created migration to remove camelcasing from db attributes

### DIFF
--- a/config/initializers/camel_model_attributes.rb
+++ b/config/initializers/camel_model_attributes.rb
@@ -1,4 +1,4 @@
 SingleUseLink.class_eval do
-  alias_attribute :itemId, :itemid
-  alias_attribute :downloadKey, :downloadkey
+  alias_attribute :itemId, :item_id
+  alias_attribute :downloadKey, :download_key
 end

--- a/db/migrate/20180618163008_rename_single_use_link_attributes.rb
+++ b/db/migrate/20180618163008_rename_single_use_link_attributes.rb
@@ -1,0 +1,6 @@
+class RenameSingleUseLinkAttributes < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :single_use_links, :downloadKey, :download_key
+    rename_column :single_use_links, :itemId, :item_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170515160517) do
+ActiveRecord::Schema.define(version: 20180618163008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.integer  "user_id",       null: false
+    t.string   "user_type"
+    t.string   "document_id"
+    t.string   "document_type"
+    t.string   "title"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["document_id"], name: "index_bookmarks_on_document_id", using: :btree
+    t.index ["user_id"], name: "index_bookmarks_on_user_id", using: :btree
+  end
 
   create_table "checksum_audit_logs", force: :cascade do |t|
     t.string   "file_set_id"
@@ -272,12 +284,12 @@ ActiveRecord::Schema.define(version: 20170515160517) do
   end
 
   create_table "single_use_links", force: :cascade do |t|
-    t.string   "downloadKey"
+    t.string   "download_key"
     t.string   "path"
-    t.string   "itemId"
+    t.string   "item_id"
     t.datetime "expires"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "sipity_agents", force: :cascade do |t|


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/457

since the upstream fix is blocked: https://github.com/samvera/hyrax/pull/3121 (at least for now), this change should get us up and running again. 

note: i based this branch off of master after merging in the rubocop+other changes this morning. After running `rake db:migrate` the resulting `db/schema.rb` file looks odd since it's creating a bookmarks table (which should already exist) and removing a `cloud_storage_archives` table, which doesn't have an associated migration. why are those changing? 