### PR TITLE
Download all files in a work as zip

### DIFF
--- a/.docker-stack/nufia7-development/docker-compose.yml
+++ b/.docker-stack/nufia7-development/docker-compose.yml
@@ -1,10 +1,11 @@
 ---
 version: '3.4'
 volumes:
-  fedora: 
-  solr: 
-  db: 
-  localstack: 
+  fedora:
+  solr:
+  db:
+  localstack:
+  minio:
 services:
   fedora:
     image: nulib/fcrepo4
@@ -56,6 +57,19 @@ services:
     - POSTGRES_PASSWORD=d0ck3r
     ports:
     - 5433:5432
+  minio:
+    image: minio/minio
+    volumes:
+      - minio:/data
+    ports:
+      - "9001:9000"
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    command:
+      - minio
+      - server
+      - /data
   localstack:
     image: localstack/localstack
     ports:

--- a/.docker-stack/nufia7-test/docker-compose.yml
+++ b/.docker-stack/nufia7-test/docker-compose.yml
@@ -1,10 +1,11 @@
 ---
 version: '3.4'
 volumes:
-  fedora: 
-  solr: 
-  db: 
-  localstack: 
+  fedora:
+  solr:
+  db:
+  localstack:
+  minio:
 services:
   fedora:
     image: nulib/fcrepo4
@@ -56,6 +57,19 @@ services:
     - POSTGRES_PASSWORD=d0ck3r
     ports:
     - 5434:5432
+  minio:
+    image: minio/minio
+    volumes:
+      - minio:/data
+    ports:
+      - "9002:9000"
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    command:
+      - minio
+      - server
+      - /data
   localstack:
     image: localstack/localstack
     ports:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,12 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 1
+Metrics/AbcSize:
+  Max: 20
+  Exclude:
+    - 'app/services/work_zip_creator.rb'
+
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
@@ -19,12 +25,14 @@ Metrics/BlockLength:
     - 'spec/models/solr_document_spec.rb'
     - 'spec/presenters/generic_work_presenter_spec.rb'
     - 'spec/factories/generic_works.rb'
-    - 'lib/tasks/s3_tasks.rake'
+    - 'spec/models/cloud_storage_archive_spec.rb'
+    - 'spec/services/work_zip_creator_spec.rb'
 
 Metrics/MethodLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
     - 'app/services/doi_minting_service.rb'
+    - 'app/services/work_zip_creator.rb'
 
 Rails/FilePath:
   Exclude:

--- a/app/assets/javascripts/download_all.js
+++ b/app/assets/javascripts/download_all.js
@@ -1,0 +1,166 @@
+$(document).ready(function() {
+  function CloudStorageArchiveDownloader(work_id) {
+    this.work_id = work_id;
+
+    if (!this.work_id) {
+      console.error(
+        "tried to create CloudStorageArchiveDownloader with missing args"
+      );
+      throw { work_id: work_id };
+    }
+  }
+
+  CloudStorageArchiveDownloader.prototype.fetchForStatus = function() {
+    var _self = this;
+
+    fetch("/concern/generic_works/" + this.work_id + "/zip", { credentials: 'include' })
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(json) {
+        if (json.status == "success") {
+          if ((existing = _self.getModal(true))) {
+            existing.modal("hide");
+          }
+          window.location = json.url;
+        } else if (json.status == "in_progress") {
+          _self.updateProgress(json);
+          _self.getModal().modal("show");
+          // wait, then check again....
+          _self.nextFetch = setTimeout(function() {
+            _self.fetchForStatus();
+          }, 2000);
+        } else {
+          json_error = JSON.parse(json.error_info);
+          if (json_error) {
+            throw json_error.class + ": " + json_error.message;
+          } else {
+            throw json;
+          }
+        }
+      })
+      .catch(function(error) {
+        _self.handleError(error);
+      });
+  };
+
+  CloudStorageArchiveDownloader.prototype.getModal = function(lazy) {
+    var _self = this;
+    if (_self.modalElement) {
+      return _self.modalElement;
+    } else if (lazy) {
+      return undefined;
+    }
+    //create a new bootstrap modal
+    var modalEl = $(
+      '\
+      <div class="modal on-demand-download" role="dialog"> \
+        <div class="modal-dialog" role="document">\
+          <div class="modal-content">\
+            <div class="modal-header">\
+              <span class="modal-title">Preparing your download</span>\
+            </div>\
+            <div class="modal-body">\
+              <div data-progress-placeholder></div>\
+              <p>Large downloads may take some time to prepare. We appreciate your patience.</p>\
+            </div>\
+            <div class="modal-footer">\
+              <button type="button" class="btn btn-primary" data-dismiss="modal">Cancel</button>\
+            </div>\
+          </div>\
+        </div>\
+      </div> \
+    '
+    );
+    $("body").append(modalEl);
+
+    modalEl.modal({
+      backdrop: true,
+      show: false
+    });
+
+    // make sure any fetches get cancelled if modal is cancelled.
+    modalEl.on("hidden.bs.modal", function(e) {
+      if (_self.nextFetch) {
+        clearTimeout(_self.nextFetch);
+        _self.nextFetch = null;
+      }
+      // and destroy the element so we can create a new one later on another
+      // click, without interfering. JQuery-based dev is a bit hacky...
+      _self.modalElement.remove();
+      _self.modalElement = null;
+    });
+
+    _self.modalElement = modalEl;
+
+    return _self.modalElement;
+  };
+
+  CloudStorageArchiveDownloader.prototype.updateProgress = function(
+    json_response
+  ) {
+    html = "";
+
+    if (
+      json_response.progress &&
+      json_response.progress_total &&
+      json_response.progress != json_response.progress_total
+    ) {
+      html =
+        '<div class="progress">' +
+        '<div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuenow="' +
+        json_response.progress +
+        '" aria-valuemax="' +
+        json_response.progress_total +
+        '"' +
+        'style="width: ' +
+        Math.floor(
+          (json_response.progress / json_response.progress_total) * 100
+        ) +
+        '%;"' +
+        ">" +
+        "</div>" +
+        "</div>";
+    } else if (
+      json_response.progress &&
+      json_response.progress_total &&
+      json_response.progress == json_response.progress_total
+    ) {
+      html =
+        '<div class="progress progress-striped active">\
+              <div class="progress-bar"  role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">' +
+        " Finishing... " +
+        "</div>" +
+        "</div>";
+    } else {
+      html =
+        '<div class="progress progress-striped active">\
+              <div class="progress-bar"  role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">' +
+        "</div>\
+            </div>";
+    }
+    this.getModal()
+      .find("*[data-progress-placeholder]")
+      .html(html);
+  };
+
+  CloudStorageArchiveDownloader.prototype.handleError = function(error) {
+    console.log("Error fetching cloud storage archive: " + error);
+    this.getModal()
+      .find(".modal-body")
+      .html(
+        '<h1 class="h2"><i class="fa fa-warning text-danger"></i> A software error occured.</h1>' +
+          "<p>We're sorry, your download can not be delivered at this time.</p>"
+      );
+    this.getModal().modal("show");
+  };
+
+  $(document).on("click", "*[data-download-whole-work-deriv]", function(e) {
+    e.preventDefault();
+
+    var target = $(e.target).closest("a");
+    var id = target.data("download-whole-work-deriv");
+    var downloader = new CloudStorageArchiveDownloader(id);
+    downloader.fetchForStatus();
+  });
+});

--- a/app/controllers/cloud_storage_archives_controller.rb
+++ b/app/controllers/cloud_storage_archives_controller.rb
@@ -1,0 +1,24 @@
+class CloudStorageArchivesController < ApplicationController
+  before_action do
+    authorize! :show, presenter.solr_document
+  end
+
+  def zip
+    record = CloudStorageArchive.find_or_create_record(work_id, work_presenter: presenter)
+
+    render json: record.as_json(methods: (record.success? ? 'url' : nil))
+  end
+
+  protected
+
+    def work_id
+      @work_id = params.require(:id)
+    end
+
+    def presenter
+      @presenter ||= GenericWorkPresenter.new(
+        SolrDocument.find(work_id),
+        Ability.new(current_user)
+      )
+    end
+end

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -1,0 +1,51 @@
+module Hyrax
+  class FileSetIndexer < ActiveFedora::IndexingService
+    include Hyrax::IndexesThumbnails
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+
+    def generate_solr_document # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      super.tap do |solr_doc|
+        solr_doc[Solrizer.solr_name('hasRelatedMediaFragment', :symbol)] = object.representative_id
+        solr_doc[Solrizer.solr_name('hasRelatedImage', :symbol)] = object.thumbnail_id
+        # Label is the actual file name. It's not editable by the user.
+        solr_doc[Solrizer.solr_name('label')] = object.label
+        solr_doc[Solrizer.solr_name('label', :stored_sortable)] = object.label
+        solr_doc[Solrizer.solr_name('file_format')] = file_format
+        solr_doc[Solrizer.solr_name('file_format', :facetable)] = file_format
+        solr_doc[Solrizer.solr_name(:file_size, STORED_LONG)] = object.file_size[0]
+        solr_doc['all_text_timv'] = object.extracted_text.content if object.extracted_text.present?
+        solr_doc['height_is'] = Integer(object.height.first) if object.height.present?
+        solr_doc['width_is'] = Integer(object.width.first) if object.width.present?
+        solr_doc[Solrizer.solr_name('mime_type', :stored_sortable)] = object.mime_type
+        solr_doc['thumbnail_path_ss'] = thumbnail_path
+        # Index the Fedora-generated SHA1 digest to create a linkage
+        # between files on disk (in fcrepo.binary-store-path) and objects
+        # in the repository.
+        solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
+        solr_doc[Solrizer.solr_name('page_count')] = object.page_count
+        solr_doc[Solrizer.solr_name('file_title')] = object.file_title
+        solr_doc[Solrizer.solr_name('duration')] = object.duration
+        solr_doc[Solrizer.solr_name('sample_rate')] = object.sample_rate
+        solr_doc[Solrizer.solr_name('original_checksum')] = object.original_checksum
+        solr_doc['visibility_ssi'] = object.visibility
+      end
+    end
+
+    private
+
+      def digest_from_content
+        return unless object.original_file
+        object.original_file.digest.first.to_s
+      end
+
+      def file_format # rubocop:disable Metrics/AbcSize
+        if object.mime_type.present? && object.format_label.present?
+          "#{object.mime_type.split('/').last} (#{object.format_label.join(', ')})"
+        elsif object.mime_type.present?
+          object.mime_type.split('/').last
+        elsif object.format_label.present?
+          object.format_label
+        end
+      end
+  end
+end

--- a/app/jobs/remote_archive_job.rb
+++ b/app/jobs/remote_archive_job.rb
@@ -1,0 +1,31 @@
+class RemoteArchiveJob < ApplicationJob
+  queue_as :default
+
+  def perform(archive)
+    working_dir = WorkZipCreator.working_dir
+    FileUtils.mkdir_p(working_dir)
+    tmp_file = Tempfile.new("zip_#{archive.id}", working_dir).tap(&:binmode)
+    create_and_upload_archive(archive, tmp_file)
+  rescue StandardError => e
+    Rails.logger.error e
+    archive.update(status: 'error', error_info: { class: e.class.name, message: e.message, backtrace: e.backtrace }.to_json)
+  ensure
+    cleanup_tmp_file(tmp_file)
+  end
+
+  private
+
+    def create_and_upload_archive(archive, tmp_file)
+      WorkZipCreator.new(archive.work_id).create_zip(filepath: tmp_file.path, callback: lambda do |progress_i:, progress_total:|
+        archive.update(progress: progress_i, progress_total: progress_total)
+      end)
+      tmp_file.rewind
+      archive.write_from_path(tmp_file.path)
+      archive.update(status: 'success', byte_size: tmp_file.size)
+    end
+
+    def cleanup_tmp_file(tmp_file)
+      tmp_file.close
+      tmp_file.unlink
+    end
+end

--- a/app/models/cloud_storage_archive.rb
+++ b/app/models/cloud_storage_archive.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Tracks zipped work files that are created on demand, and then cached in a store.
+# The store is expected to be purged periodically, which the db is not told about,
+# so the actual file may not exist.
+#
+# This model is responsible for determining the file name, created from work id
+# and checksum, so if the checksum changes, we'll look for a new file and not
+# use the old one (which will then be eventually purged by the store)
+class CloudStorageArchive < ApplicationRecord
+  STALE_IN_PROGRESS_SECONDS = 20.minutes
+  ERROR_RETRY_SECONDS = 10.minutes
+
+  enum status: %w[in_progress success error].map { |v| [v, v] }.to_h.freeze
+
+  delegate :file_exists?, :url, :write_from_path, to: :resource_locator
+
+  def file_name
+    "#{work_id}_#{checksum}.zip"
+  end
+
+  def work_presenter
+    @work_presenter ||= GenericWorkPresenter.new(
+      SolrDocument.find(work_id),
+      Ability.new(nil)
+    )
+  end
+
+  def self.find_or_create_record(id, work_presenter: nil)
+    FindOrCreator.new(id, work_presenter: work_presenter).find_or_create_record
+  end
+
+  protected
+
+    def resource_locator
+      @resource_locator ||= S3File.new(self, Settings.aws.buckets.archives)
+    end
+
+    class FindOrCreator
+      attr_reader :work_id
+
+      def initialize(work_id, work_presenter: nil)
+        @work_id = work_id
+        @work_presenter = work_presenter
+      end
+
+      def find_or_create_record(retry_count: 0)
+        raise StandardError, "Tried to find/create an CloudStorageArchive record too many times for work #{work_id}" if retry_count > 10
+
+        record = CloudStorageArchive.find_by(work_id: work_id)
+        if record.nil?
+          record = CloudStorageArchive.create(work_id: work_id, status: :in_progress, checksum: checksum)
+          RemoteArchiveJob.perform_later(record)
+        end
+        if disqualified?(record)
+          record.delete
+          record = find_or_create_record(retry_count: retry_count + 1)
+        end
+
+        return record
+      rescue ActiveRecord::RecordNotUnique
+        # race condition, someone else created it, no biggy
+        return find_or_create_record(retry_count: retry_count + 1)
+      end
+
+      def work_presenter
+        @work_presenter ||= GenericWorkPresenter.new(
+          SolrDocument.find(work_id),
+          Ability.new(nil)
+        )
+      end
+
+      def checksum
+        @checksum ||= Digest::MD5.hexdigest(work_presenter.public_member_presenters.map do |p|
+          p.solr_document['digest_ssim'].first.delete('urn:sha1:')
+        end.join('-'))
+      end
+
+      private
+
+        def disqualified?(record)
+          stalled?(record) || unrecoverable_error?(record) || checksum_mismatch?(record) || file_missing?(record)
+        end
+
+        def stalled?(record)
+          record.in_progress? && (Time.current - record.updated_at) > CloudStorageArchive::STALE_IN_PROGRESS_SECONDS
+        end
+
+        def unrecoverable_error?(record)
+          record.error? && (Time.current - record.updated_at) > CloudStorageArchive::ERROR_RETRY_SECONDS
+        end
+
+        def checksum_mismatch?(record)
+          record.success? && record.checksum != checksum
+        end
+
+        def file_missing?(record)
+          record.success? && !record.file_exists?
+        end
+    end
+
+    class S3File
+      attr_reader :bucket, :model
+
+      def initialize(model, bucket_name)
+        @model = model
+        @bucket = Aws::S3::Bucket.new(bucket_name)
+      end
+
+      def file_exists?
+        bucket.object(key_path).exists?
+      end
+
+      def url
+        @url ||= bucket.object(key_path).presigned_url(:get,
+                                                       expires_in: 7.days.to_i,
+                                                       response_content_type: 'application/zip',
+                                                       response_content_disposition: encoding_safe_content_disposition('test.zip'))
+      end
+
+      def write_from_path(path)
+        bucket.object(key_path).upload_file(path)
+      end
+
+      protected
+
+        def key_path
+          @keypath ||= Pathname.new(model.file_name).to_s
+        end
+
+      private
+
+        def encoding_safe_content_disposition(file_name)
+          "attachment; filename=\"#{file_name.encode('US-ASCII', undef: :replace, replace: '_')}\""
+        end
+    end
+end

--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,3 +1,9 @@
 class GenericWorkPresenter < Hyrax::WorkShowPresenter
   delegate :doi, to: :solr_document
+
+  def public_member_presenters
+    @public_member_presenters ||= file_set_presenters.find_all do |m|
+      m.solr_document['visibility_ssi'] == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
 end

--- a/app/services/work_zip_creator.rb
+++ b/app/services/work_zip_creator.rb
@@ -1,0 +1,87 @@
+class WorkZipCreator
+  class_attribute :working_dir
+  self.working_dir = Pathname.new(Dir.tmpdir).join('nulib_zip_create')
+
+  attr_reader :work_id
+
+  def initialize(work_id)
+    @work_id = work_id
+  end
+
+  # Writes zip to specified path, if path not given will write to a tempfile, and return
+  # it _without_ closing/unlinking it.
+  def create_zip(filepath: nil, callback: nil)
+    if filepath.nil?
+      # See http://thinkingeek.com/2013/11/15/create-temporary-zip-file-send-response-rails/
+      # for explanation of the way we are using Zip library that looks weird.
+
+      FileUtils.mkdir_p working_dir
+      tmp_file = Tempfile.new("zip-#{work_id}", working_dir).tap(&:binmode)
+      Zip::OutputStream.open(tmp_file) { |z| }
+      filepath = tmp_file.path
+    end
+
+    tmp_comment_file = Tempfile.new("zip-#{work_id}-comment", working_dir)
+    tmp_comment_file.write(comment_text)
+    tmp_comment_file.rewind
+
+    count = work_presenter.public_member_presenters.size
+
+    Zip::File.open(filepath, Zip::File::CREATE) do |zipfile|
+      zipfile.comment = comment_text
+
+      zipfile.add('about.txt', tmp_comment_file)
+
+      work_presenter.public_member_presenters.each_with_index do |file_set_presenter, index|
+        file_set = FileSet.find(file_set_presenter.id)
+        filename = "#{format '%03d', index + 1}-#{work_id}-#{file_set.id}-#{file_set.label}"
+
+        url = file_set.original_file.uri.value
+        output = Pathname.new(working_dir).join(filename)
+
+        open(url) do |io|
+          IO.copy_stream(io, output)
+        end
+
+        zipfile.add(filename, output)
+
+        callback&.call(progress_total: count, progress_i: index + 1)
+      end
+    end
+
+    return tmp_file
+  ensure
+    tmp_comment_file.close
+    tmp_comment_file.unlink
+  end
+
+  protected
+
+    def work_presenter
+      @work_presenter ||= begin
+        solr_doc = SolrDocument.find(work_id) # CloudStorageArchive
+        GenericWorkPresenter.new(solr_doc, Ability.new(nil))
+      end
+    end
+
+    def comment_text
+      @comment_text ||= <<~EOS
+        Courtesy of Northwestern University Libraries
+         #{work_presenter.title.first}
+         Work #{work_id}
+         Prepared on #{Time.zone.now}
+      EOS
+    end
+
+  private
+
+    def get_file_sets(presenter)
+      presenter.member_presenters.each do |member|
+        if member.is_a?(Hyrax::FileSetPresenter)
+          @file_set_ids << member.id
+        else
+          get_file_sets(member)
+        end
+      end
+    end
+end

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -24,6 +24,9 @@
     <%= render "show_actions", presenter: @presenter %>
     <%= t('.last_modified', value: @presenter.date_modified) %>
     <%= render 'representative_media', presenter: @presenter %>
+    <% if (@presenter.public_member_presenters.any?) %>
+      <%= link_to("Download All Files (.zip)".html_safe, '', data: { 'download-deriv-type': 'zip', 'download-whole-work-deriv': @presenter.id}, class: 'btn btn-default') %>
+    <% end %>
     <%= render 'social_media' %>
     <%= render 'citations', presenter: @presenter %>
   </div>

--- a/config/initializers/aws_sdk.rb
+++ b/config/initializers/aws_sdk.rb
@@ -1,9 +1,10 @@
 if Settings.localstack
-  # Use localstack for AWS services
-  require 'docker/stack/localstack/endpoint_stub'
-  Docker::Stack::Localstack::EndpointStub.stub_endpoints!
+  require 'aws-sdk-s3'
 
   Aws.config.update(
+    endpoint: Settings.aws.endpoint,
+    access_key_id: 'minio',
+    secret_access_key: 'minio123',
     force_path_style: true,
     region: 'us-east-1'
   )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,4 +44,6 @@ Rails.application.routes.draw do
   end
 
   get 'rights' => 'hyrax/pages#show', id: 'rights_page'
+
+  get '/concern/generic_works/:id/zip', to: 'cloud_storage_archives#zip', as: :download_all
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,6 +4,9 @@ localstack:
 active_job:
   queue_adapter: inline
 aws:
+  endpoint: http://localhost:9001
+  buckets:
+    archives: dev-archives
   queues:
     default: arch-queue
 doi_credentials:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,7 @@ localstack:
 active_job:
   queue_adapter: inline
 aws:
+  endpoint: http://localhost:9002
   buckets:
     archives: test-archives
 doi_credentials:

--- a/db/migrate/20180614181606_create_cloud_storage_archives.rb
+++ b/db/migrate/20180614181606_create_cloud_storage_archives.rb
@@ -1,0 +1,17 @@
+class CreateCloudStorageArchives < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cloud_storage_archives do |t|
+      t.string   :work_id, null: false
+      t.string   :status, default: "in_progress"
+      t.string   :checksum, null: false
+      t.text     :error_info
+      t.integer  :progress
+      t.integer  :progress_total
+      t.integer  :byte_size
+
+      t.timestamps
+    end
+
+    add_index :cloud_storage_archives, :work_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,19 @@ ActiveRecord::Schema.define(version: 20180618163008) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id", using: :btree
   end
 
+  create_table "cloud_storage_archives", force: :cascade do |t|
+    t.string   "work_id",                                null: false
+    t.string   "status",         default: "in_progress"
+    t.string   "checksum",                               null: false
+    t.text     "error_info"
+    t.integer  "progress"
+    t.integer  "progress_total"
+    t.integer  "byte_size"
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.index ["work_id"], name: "index_cloud_storage_archives_on_work_id", unique: true, using: :btree
+  end
+
   create_table "content_blocks", force: :cascade do |t|
     t.string   "name"
     t.text     "value"

--- a/lib/tasks/s3_tasks.rake
+++ b/lib/tasks/s3_tasks.rake
@@ -1,56 +1,44 @@
+# frozen_string_literal: true
 
-namespace :s3 do
-  desc 'Create all configured S3 buckets'
-  task create_buckets: :environment do
-    Settings.aws.buckets.to_h.values.each do |bucket|
-      bucket = Aws::S3::Bucket.new(bucket)
-      bucket.create unless bucket.exists?
-    end
-  end
+if Rails.env.development? || Rails.env.test?
+  require 'aws-sdk-s3'
 
-  desc 'Populate S3 batch bucket with fixture data'
-  task populate_batch_buckets: :environment do
-    s3 = Aws::S3::Resource.new
-    Settings.aws.buckets.to_h.each_pair do |key, bucket|
-      fixture_dir = Rails.root.join('spec', 'fixtures', 's3', key)
-      next unless File.directory?(fixture_dir)
-      Dir.chdir(fixture_dir) do
-        Dir.glob('**/*').each do |file|
-          next if File.directory?(file)
-          obj = s3.bucket(bucket).object(file)
-          obj.upload_file(file)
-        end
+  Aws.config.update(
+    endpoint: Settings.aws.endpoint,
+    access_key_id: 'minio',
+    secret_access_key: 'minio123',
+    force_path_style: true,
+    region: 'us-east-1'
+  )
+
+  namespace :s3 do
+    desc 'Create buckets'
+    task :setup do
+      Settings.aws.buckets.to_h.values.each do |bucket|
+        bucket = Aws::S3::Bucket.new(bucket)
+        bucket.create unless bucket.exists?
       end
     end
-  end
 
-  desc 'Create buckets and populate with test data'
-  task :setup do
-    Rake::Task['s3:create_buckets'].invoke
-    Rake::Task['s3:populate_batch_buckets'].invoke
-  end
-
-  desc 'Empty S3 buckets'
-  task empty_buckets: :environment do
-    client = Aws::S3::Client.new
-    Settings.aws.buckets.to_h.values.each do |bucket|
-      objs = client.list_objects_v2(bucket: bucket)
-      objs.contents.each do |obj|
-        client.delete_object(bucket: bucket, key: obj.key)
+    desc 'Empty S3 buckets'
+    task empty_buckets: :environment do
+      Settings.aws.buckets.to_h.values.each do |bucket|
+        bucket = Aws::S3::Bucket.new(bucket)
+        bucket.objects.each(&:delete)
       end
     end
-  end
 
-  desc 'Delete S3 buckets'
-  task delete_buckets: :environment do
-    Settings.aws.buckets.to_h.values.each do |bucket|
-      Aws::S3::Client.new.delete_bucket(bucket: bucket)
+    desc 'Delete S3 buckets'
+    task delete_buckets: :environment do
+      Settings.aws.buckets.to_h.values.each do |bucket|
+        Aws::S3::Client.new.delete_bucket(bucket: bucket)
+      end
     end
-  end
 
-  desc 'Empty and delete S3 buckets'
-  task :teardown do
-    Rake::Task['s3:empty_buckets'].invoke
-    Rake::Task['s3:delete_buckets'].invoke
+    desc 'Empty and delete S3 buckets'
+    task :teardown do
+      Rake::Task['s3:empty_buckets'].invoke
+      Rake::Task['s3:delete_buckets'].invoke
+    end
   end
 end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -20,7 +20,8 @@ FactoryBot.define do
         fileset = FactoryBot.create(:file_set,
                                     user: evaluator.user,
                                     title: ["#{File.basename(evaluator.image_path)}_#{i + 1}_#{evaluator.title.first}"],
-                                    label: File.basename(evaluator.image_path))
+                                    label: File.basename(evaluator.image_path),
+                                    visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
         work.ordered_members << fileset
         work.representative = fileset
         work.thumbnail = fileset

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -1,0 +1,21 @@
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyrax::FileSetIndexer do
+  let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  let(:solr_doc) { described_class.new(file_set).generate_solr_document }
+
+  let(:file_set) { FactoryBot.create(:file_set, visibility: visibility) }
+
+  before do
+    allow(file_set).to receive(:visibility).and_return(visibility)
+  end
+
+  describe '#generate_solr_document' do
+    it 'indexes the visibility' do
+      expect(solr_doc['visibility_ssi']).to eq(visibility)
+    end
+  end
+end

--- a/spec/jobs/remote_archive_job_spec.rb
+++ b/spec/jobs/remote_archive_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe RemoteArchiveJob, type: :job do
+  let(:archive) { CloudStorageArchive.create(work_id: 'fake_id', checksum: 'fake_checksum') }
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  describe '#perform_later' do
+    it 'enqueues jobs' do
+      expect do
+        described_class.perform_later('1234')
+      end.to have_enqueued_job
+    end
+
+    it 'updates the archive status on error' do
+      described_class.perform_now(archive)
+      expect(archive.status).to eq 'error'
+      expect(archive.error_info).not_to be_empty
+    end
+  end
+end

--- a/spec/models/cloud_storage_archive_spec.rb
+++ b/spec/models/cloud_storage_archive_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CloudStorageArchive do
+  let(:work) { FactoryBot.create(:work) }
+  let(:sample_file_path) { (Rails.root + 'spec/fixtures/coffee.jpg').to_s }
+  let(:bucket) { Aws::S3::Bucket.new(Settings.aws.buckets.archives) }
+
+  context 'uploads files to S3' do
+    let(:instance) { described_class.create(work_id: work.id, checksum: 'fake_checksum') }
+
+    describe '.write_from_path' do
+      it 'writes to store' do
+        instance.write_from_path(sample_file_path)
+        expect(bucket.objects.count).to eq 1
+      end
+
+      it 'has a url' do
+        expect(instance.url).to start_with('http://')
+      end
+    end
+  end
+
+  context 'uses previously created archive if possible' do
+    describe '#find_or_create_record' do
+      it 'creates if archive is not found or there is a problem' do
+        expect { described_class.find_or_create_record(work.id) }.to have_enqueued_job(RemoteArchiveJob).once
+      end
+
+      it 'returns an archive if it is found' do
+        expect do
+          described_class.find_or_create_record(work.id)
+          described_class.find_or_create_record(work.id)
+        end.to have_enqueued_job(RemoteArchiveJob).once
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'rake'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -54,4 +55,16 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:suite) do
+    Rake.application.rake_require 'tasks/s3_tasks'
+    Rake::Task.define_task(:environment)
+    Rake::Task['s3:setup'].invoke
+  end
+
+  config.after(:suite) do
+    Rake.application.rake_require 'tasks/s3_tasks'
+    Rake::Task.define_task(:environment)
+    Rake::Task['s3:teardown'].invoke
+  end
 end

--- a/spec/services/work_zip_creator_spec.rb
+++ b/spec/services/work_zip_creator_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe WorkZipCreator do
+  before do
+    allow(Hydra::Works::CharacterizationService).to receive(:run).and_return(nil)
+  end
+
+  let(:callback_spy) { instance_spy('callback') }
+  let!(:work) { FactoryBot.create(:work, num_images: 2) }
+
+  # rubocop:disable RSpec/ExampleLength
+  it 'zips members of a work' do
+    creator = described_class.new(work.id)
+    zip_file = creator.create_zip
+
+    found_entries = []
+    Zip::File.open(zip_file.path) do |zip|
+      expect(zip.comment).to include 'Northwestern University Libraries'
+
+      zip.each do |entry|
+        found_entries << { name: entry.name, size: entry.size }
+      end
+    end
+
+    expect(found_entries.size).to eq 3
+    expect(found_entries.find { |e| e[:name] == 'about.txt' }).not_to be nil
+
+    cleanup(zip_file)
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  it 'only includes \'open\' files' do
+    file_set = work.file_sets.first
+    file_set.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    file_set.save!
+    zip_file = described_class.new(work.id).create_zip
+
+    expect(Zip::File.open(zip_file.path).entries.count).to eq(2)
+  end
+
+  it 'updates progress with an optional callback' do
+    zip_file = described_class.new(work.id).create_zip(callback: callback_spy)
+
+    expect(callback_spy).to have_received(:call).with(progress_total: 2, progress_i: 1)
+    expect(callback_spy).to have_received(:call).with(progress_total: 2, progress_i: 2)
+    expect(callback_spy).not_to have_received(:call).with(progress_total: 2, progress_i: 3)
+
+    cleanup(zip_file)
+  end
+
+  private
+
+    def cleanup(zip_file)
+      zip_file.close
+      zip_file.unlink
+    end
+end


### PR DESCRIPTION
### Description
Implements a "Download All" button on the Work page which allows a user to download all public files attached to the work in one .zip file

### Changes in this PR
Adds RemoteArchiveJob and specs
Adds CloudStorageArchive model, migration and specs
Indexes visibility on FileSet
Adds CloudStorageArchivesController and generic_works zip route
Adds minio dev and test dependency
Adds public_member_presenters method to GenericWorkPresenter
Adds button to download all public files
Adds JavaScript for modal popup with progress bar
Fixes s3 rake tasks

Co-authored-by: Brendan  Quinn <brendan-quinn@northwestern.edu>

Fixes #https://github.com/nulib/institutional-repository/issues/258