### PR TITLE
Use Hyrax configured queue

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
 class ApplicationJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
 end

--- a/app/jobs/remote_archive_job.rb
+++ b/app/jobs/remote_archive_job.rb
@@ -1,6 +1,4 @@
 class RemoteArchiveJob < ApplicationJob
-  queue_as :default
-
   def perform(archive)
     working_dir = WorkZipCreator.working_dir
     FileUtils.mkdir_p(working_dir)


### PR DESCRIPTION
Fixes RemoteArchiveJob queuing functionality in AWS environment.

- Adds Hyrax.config.ingest_queue_name to `ApplicationJob`
- Removes `:default` from `RemoteArchiveJob`