### PR TITLE
Add rubyzip to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'ezid-client'
+gem 'rubyzip', '>= 1.0.0', require: 'zip'
 gem 'sidekiq'
 gem 'sinatra', '>= 2.0.0', require: nil
 gem 'yaml_db'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1449,6 +1449,7 @@ DEPENDENCIES
   rspec-rails (~> 3.6)
   rubocop (~> 0.49.1)
   rubocop-rspec
+  rubyzip (>= 1.0.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sidekiq


### PR DESCRIPTION
- Adds `rubyzip` gem to fix `uninitialized constant WorkZipCreator::Zip` error in download all feature.

Co-authored-by: Karen Didrickson <karendid@gmail.com>
Co-authored-by: Michael Klein <mbklein@gmail.com>
