### PR TITLE
Set default queue name on Hyrax jobs that don't specify one

### DIFF
--- a/config/initializers/set_hyrax_job_queue_names.rb
+++ b/config/initializers/set_hyrax_job_queue_names.rb
@@ -1,0 +1,3 @@
+[AuditJob, InheritPermissionsJob, ResolrizeJob, VisibilityCopyJob].each do |klass|
+  klass.class_eval { queue_as Hyrax.config.ingest_queue_name }
+end


### PR DESCRIPTION
Set the correct queue name on Hyrax jobs that don't properly descend from `ApplicationJob` or specify the Hyrax ingest queue.

Fixes: https://github.com/nulib/institutional-repository/issues/488