### PR TITLE
Simplify zip file names in WorkZipCreator, improve download all button

### DIFF
--- a/app/services/work_zip_creator.rb
+++ b/app/services/work_zip_creator.rb
@@ -34,7 +34,7 @@ class WorkZipCreator
 
       work_presenter.public_member_presenters.each_with_index do |file_set_presenter, index|
         file_set = FileSet.find(file_set_presenter.id)
-        filename = "#{format '%03d', index + 1}-#{work_id}-#{file_set.id}-#{file_set.label}"
+        filename = "#{format '%03d', index + 1}-#{file_set.label}"
 
         url = file_set.original_file.uri.value
         output = Pathname.new(working_dir).join(filename)

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -25,7 +25,7 @@
     <%= t('.last_modified', value: @presenter.date_modified) %>
     <%= render 'representative_media', presenter: @presenter %>
     <% if (@presenter.public_member_presenters.any?) %>
-      <%= link_to("Download All Files (.zip)".html_safe, '', data: { 'download-deriv-type': 'zip', 'download-whole-work-deriv': @presenter.id}, class: 'btn btn-default') %>
+      <div class="show-actions"><%= link_to("Download All Files (.zip)".html_safe, '', data: { 'download-deriv-type': 'zip', 'download-whole-work-deriv': @presenter.id}, class: 'btn btn-default') %></div>
     <% end %>
     <%= render 'social_media' %>
     <%= render 'citations', presenter: @presenter %>


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/486; https://github.com/nulib/institutional-repository/issues/490

- Fixes the file names of files added to zips in the WorkZipCreator, prepends each file name with the (ordered) index number of each file in the work, e.g. `001-test.jpg`, `002-test.jpg`
- Wraps the "Download All Files" button in a div with the `show-actions` class to add padding around the button
 