### PR TITLE
update ImportUrlJob to find operation correctly

### DIFF
--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -11,7 +11,7 @@ class ImportUrlJob < ApplicationJob
   attr_reader :file_set, :operation
 
   before_enqueue do |job|
-    operation = job.arguments.last
+    operation = job.arguments[1]
     operation.pending_job(job)
   end
 


### PR DESCRIPTION
* Fix bug where ImportUrlJob may not be able to find operation if `headers` are passed in.