### PR TITLE
Tombstone doi

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,6 +15,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/services/doi_minting_service.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -5,6 +5,7 @@ class GenericWork < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
+
   validates :title, presence: { message: 'Your work must have a title.' }
 
   self.human_readable_type = 'Work'
@@ -15,5 +16,9 @@ class GenericWork < ActiveFedora::Base
 
   after_save do
     DoiMintingService.mint_identifier_for(self) if doi.nil?
+  end
+
+  before_destroy do
+    DoiMintingService.tombstone_identifier_for(self) if doi
   end
 end

--- a/app/services/doi_minting_service.rb
+++ b/app/services/doi_minting_service.rb
@@ -8,6 +8,10 @@ class DoiMintingService
     DoiMintingService.new(work).run
   end
 
+  def self.tombstone_identifier_for(work)
+    DoiMintingService.new(work).tombstone
+  end
+
   def initialize(obj)
     @work = obj
   end
@@ -21,7 +25,18 @@ class DoiMintingService
     end
   end
 
+  def tombstone
+    return unless identifier_server_reachable?
+    tombstone_identifier if work.doi.present?
+  end
+
   private
+
+    def tombstone_identifier
+      identifier = minter.find(work.doi)
+      identifier.status = Ezid::Status::UNAVAILABLE
+      identifier.save
+    end
 
     def update_metadata
       return if minter_user == 'apitest'

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -17,5 +17,11 @@ RSpec.describe GenericWork do
     it 'creates a doi after a save' do
       expect(work.doi).to start_with('doi')
     end
+
+    it 'tombstones a doi when the work is destroyed' do
+      allow(DoiMintingService).to receive(:tombstone_identifier_for)
+      work.destroy
+      expect(DoiMintingService).to have_received(:tombstone_identifier_for)
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/327

When a work is destroyed, we mark the DOI as 'unavailable', which tombstones it