### PR TITLE
Doi links

### DIFF
--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,5 +1,7 @@
 class GenericWorkPresenter < Hyrax::WorkShowPresenter
-  delegate :doi, to: :solr_document
+  def doi
+    "https://doi.org/#{solr_document.doi.first.split(':').last}"
+  end
 
   def public_member_presenters
     @public_member_presenters ||= file_set_presenters.find_all do |m|

--- a/spec/features/show_generic_work_spec.rb
+++ b/spec/features/show_generic_work_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Display a musical work' do
     GenericWork.new.tap do |work|
       work.creator = ['Creator 1']
       work.title = ['work title']
-      work.doi = 'test doi'
+      work.doi = 'doi:test_doi'
       work.apply_depositor_metadata('user')
       work.visibility = 'open'
       work.save
@@ -18,7 +18,7 @@ RSpec.feature 'Display a musical work' do
       visit(hyrax_generic_work_path(work.id))
       expect(page).to have_content('Creator 1')
       expect(page).to have_content('work title')
-      expect(page).to have_content('test doi')
+      expect(page).to have_content('https://doi.org/test_doi')
     end
   end
 end

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -8,7 +8,7 @@ describe GenericWorkPresenter do
       work.id = 'work-id'
       work.creator = ['Creator 1']
       work.title = ['work title']
-      work.doi = 'test doi'
+      work.doi = 'doi:test_doi'
     end
   end
 
@@ -30,7 +30,7 @@ describe GenericWorkPresenter do
 
   describe '#doi' do
     it 'returns the doi' do
-      expect(subject.doi).to eq(['test doi'])
+      expect(subject.doi).to eq('https://doi.org/test_doi')
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/511

instead of delegating to the raw data in the solr doc, create a clickable link from the data