### PR TITLE
adds autosuggest for FAST to subject field

### DIFF
--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,9 @@
+<%=
+  f.input key,
+  as: :multi_value,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/assign_fast/all",
+      'autocomplete' => key }
+  } ,
+  required: f.object.required?(key) %>

--- a/spec/views/records/edit_fields/_subject.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_subject.html.erb_spec.rb
@@ -1,0 +1,23 @@
+
+require 'rails_helper'
+
+RSpec.describe 'records/edit_fields/_subject.html.erb', type: :view do
+  let(:work) { FactoryBot.create(:work) }
+  let(:form) { Hyrax::GenericWorkForm.new(work, nil, nil) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "records/edit_fields/subject", f: f, key: 'subject' %>
+      <% end %>
+    )
+  end
+
+  before do
+    assign(:form, form)
+    render inline: form_template
+  end
+
+  it 'has url for autocomplete service' do
+    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/assign_fast/all"][data-autocomplete="subject"]')
+  end
+end


### PR DESCRIPTION
Fixes #https://github.com/nulib/institutional-repository/issues/47

* Adds autosuggest for FAST subject headings in the Subject field on the New/Edit Work form