### PR TITLE
description/abstracts wont be so long on search results page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -64,7 +64,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
-    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
+    config.add_index_field solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :truncated_summary
     config.add_index_field solr_name('keyword', :stored_searchable), itemprop: 'keywords', link_to_search: solr_name('keyword', :facetable)
     config.add_index_field solr_name('subject', :stored_searchable), itemprop: 'about', link_to_search: solr_name('subject', :facetable)
     config.add_index_field solr_name('creator', :stored_searchable), itemprop: 'creator', link_to_search: solr_name('creator', :facetable)

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -2,4 +2,10 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+
+  def truncated_summary(options)
+    options[:value].map! { |val| val.truncate_words(50) }
+
+    iconify_auto_link(options)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/433#issuecomment-402772030

Thanks OSU

updated the PR to both truncate the abstract as well as still execute the original `iconify_auto_link` helper_method that was put onto that field. 