### PR TITLE
dont operate on empty dois

### DIFF
--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,6 +1,6 @@
 class GenericWorkPresenter < Hyrax::WorkShowPresenter
   def doi
-    "https://doi.org/#{solr_document.doi.first.split(':').last}"
+    "https://doi.org/#{solr_document.doi.first.split(':').last}" unless solr_document.doi.empty?
   end
 
   def public_member_presenters

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -33,4 +33,11 @@ describe GenericWorkPresenter do
       expect(subject.doi).to eq('https://doi.org/test_doi')
     end
   end
+
+  describe 'when doi is empty' do
+    it 'returns nil (and not an error)' do
+      work.doi = nil
+      expect(subject.doi).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
added a guard clause for doi presenter. 

fixes https://github.com/nulib/institutional-repository/pull/516