### PR TITLE
Update configs and instructions to use devstack

### DIFF
--- a/.docker-stack/nufia7-development/docker-compose.yml
+++ b/.docker-stack/nufia7-development/docker-compose.yml
@@ -17,14 +17,10 @@ services:
     image: solr:7.2-alpine
     ports:
     - 8983:8983
+    - 9983:9983
     volumes:
     - solr:/opt/solr/server/solr/mycores
-    - "../../solr:/solr_config"
-    entrypoint:
-    - docker-entrypoint.sh
-    - solr-precreate
-    - development-core
-    - "/solr_config/conf"
+    command: solr -f -cloud
     healthcheck:
       test:
       - CMD
@@ -70,21 +66,3 @@ services:
       - minio
       - server
       - /data
-  localstack:
-    image: localstack/localstack
-    ports:
-    - 4772:4572
-    volumes:
-    - localstack:/data
-    environment:
-      SERVICES: s3
-      DATA_DIR: "/data"
-    healthcheck:
-      test:
-      - CMD
-      - curl
-      - "-f"
-      - http://localhost:4572/
-      interval: 30s
-      timeout: 5s
-      retries: 3

--- a/.docker-stack/nufia7-test/docker-compose.yml
+++ b/.docker-stack/nufia7-test/docker-compose.yml
@@ -17,14 +17,10 @@ services:
     image: solr:7.2-alpine
     ports:
     - 8985:8983
+    - 9985:9983
     volumes:
     - solr:/opt/solr/server/solr/mycores
-    - "../../solr:/solr_config"
-    entrypoint:
-    - docker-entrypoint.sh
-    - solr-precreate
-    - test-core
-    - "/solr_config/conf"
+    command: solr -f -cloud
     healthcheck:
       test:
       - CMD
@@ -70,21 +66,3 @@ services:
       - minio
       - server
       - /data
-  localstack:
-    image: localstack/localstack
-    ports:
-    - 4972:4572
-    volumes:
-    - localstack:/data
-    environment:
-      SERVICES: s3
-      DATA_DIR: "/data"
-    healthcheck:
-      test:
-      - CMD
-      - curl
-      - "-f"
-      - http://localhost:4572/
-      interval: 30s
-      timeout: 5s
-      retries: 3

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'puma', '~> 3.7'
 
 gem 'docker-stack'
 
+gem 'zk'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'better_errors'
@@ -80,7 +82,6 @@ group :aws do
   gem 'carrierwave-aws'
   gem 'cloudfront-signer'
   gem 'redis-rails'
-  gem 'zk'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
   * ffmpeg `brew install ffmpeg --with-fdk-aac --with-libvpx --with-libvorbis`
   * fits `brew install fits`
   * vips `brew install vips`
+  * Install [`devstack`](https://github.com/nulib/devstack) according to the instructions in the README
 
 ## Developer Installation
 
   * Clone this repository `git clone git@github.com:nulib/institutional-repository.git`
   * From inside the project directory run `bundle install`
-  * Start the docker stack with `bundle exec rake docker:dev:up`
-  * From inside the project directory run `bundle exec rake db:setup`
+  * Start the docker stack with `devstack up arch`
+  * From inside the project directory run `bundle exec rake db:setup zookeeper:upload zookeeper:create`
 
 ## Initially running the application
 

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,13 +1,12 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/development-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/arch-development" %>
 test: &test
   adapter: solr
-  url: http://localhost:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/test-core
+  url: http://localhost:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/arch-test
 staging:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
-

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,12 +9,12 @@ default: &default
 development:
   <<: *default
   port: 5433
-  database: docker_dev
+  database: arch_dev
 
 test:
   <<: *default
   port: <%= Docker::Stack.env.development? ? 5433 : 5434 %>
-  database: docker_test
+  database: arch_test
 
 production:
   adapter: sqlite3

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -17,3 +17,6 @@ doi_credentials:
   host: 'ezid.lib.purdue.edu'
   port: 443
   use_ssl: true
+solrcloud: true
+zookeeper:
+  connection_str: "localhost:9983/configs"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -14,3 +14,6 @@ doi_credentials:
   host: 'ezid.lib.purdue.edu'
   port: 443
   use_ssl: true
+solrcloud: true
+zookeeper:
+  connection_str: "localhost:9985/configs"

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/development-core
+  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/arch-development
 test:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/test-core
+  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/arch-test
 production:
   url: http://127.0.0.1:8983/solr/arch

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -18,6 +18,8 @@ unless Rails.env.production?
       Rails.env = 'test'
       Docker::Stack::Controller.new(cleanup: true).with_containers do
         Rake::Task['db:setup'].invoke
+        Rake::Task['zookeeper:upload'].invoke
+        Rake::Task['zookeeper:create'].invoke
 
         task = get_named_task(ENV['SPEC_TASK']) ||
                get_named_task('spec') ||


### PR DESCRIPTION
This PR updates the arch dev environment to use the common [devstack](https://github.com/nulib/devstack)