### PR TITLE
Change X-Frame-Options from SAMEORIGIN to ALLOWALL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module Nufia7
         end
       end
     end
+
+    config.action_dispatch.default_headers = { 'X-Frame-Options' => 'ALLOWALL' }
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'GET #index' do
+    it 'includes X-Frame-Options: ALLOWALL' do
+      get :index
+      expect(response.headers['X-Frame-Options']).to eq 'ALLOWALL'
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,6 @@ RSpec.configure do |config|
     Rake::Task.define_task(:environment)
     Rake::Task['s3:teardown'].invoke
   end
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
Quick fix to allow @chrisdaaz to create static sites for faculty with Arch embedded in `IFRAME`s.

The current `X-Frame-Options` header value, `SAMEORIGIN`, causes browsers to reject the content. Changing the value to `ALLOWALL` will fix this, and there's no security issue with doing so.