### PR TITLE
Restores Embargo Visibility Option 

### DIFF
--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -23,8 +23,6 @@
             <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
-        <!-- Embargo hidden 9/13/2017 as it doesn't work in Hyrax 1.x -->
-        <!--
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
@@ -39,7 +37,6 @@
             </div>
           </label>
         </li>
-        -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>


### PR DESCRIPTION
Fixes #343 ; refs #322 

This uncomments a radio button in the visibility panel on the Add New Work page. This will now allow users to select an embargo option, which was broken functionality in Hyrax 1.x.

Changes proposed in this pull request:
* Changed file: `app/views/hyrax/base/_form_visibility_component.html.erb`
* UI: `http://arch.stack.rdc-staging.library.northwestern.edu/concern/generic_works/q237hs13j/edit`
