### PR TITLE
Unhides embargo radio button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Arch
-Arch is our institutional repository and is a modified Hyrax head.
+Arch is our institutional repository and is a Hyrax 2 application.
 
 ## Software Architecture
-Right now we are hosting Arch on AWS. It's using NUL's shared Fedora 4 instance and has it's own solr core on our shared Solr instance.
+Arch is hosted on AWS. It's using NUL's shared Fedora 4 instance and has it's own Solr core on a shared Solr instance.
 
 ## Developer Dependencies
 
@@ -18,26 +18,22 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
   * fits `brew install fits`
   * vips `brew install vips`
   * Install [`devstack`](https://github.com/nulib/devstack) according to the instructions in the README
+  * Follow the [Authentication Setup for Dev Environment](https://github.com/nulib/donut/wiki/Authentication-setup-for-dev-environment) instructions 
 
 ## Developer Installation
 
   * Clone this repository `git clone git@github.com:nulib/institutional-repository.git`
   * From inside the project directory run `bundle install`
   * Start the docker stack with `devstack up arch`
-  * From inside the project directory run `bundle exec rake db:setup zookeeper:upload zookeeper:create`
+  * From inside the project directory run `bundle exec rake arch:seed`
+     * You can include the optional arguments to create an admin user (such as yourself). Ex: `bundle exec rake arch:seed ADMIN_USER=your_netid ADMIN_EMAIL=your_email@northwestern.edu`
+  * In a separate tab, start the rails server `bundle exec rails server`
 
-## Initially running the application
+  ## Running the tests
 
-  * Start the Rails app `rails s`
-  * In your browser, log in using your netid
-  * Back in terminal, run the rake task `bundle exec rake add_admin_role` to make your user an admin
-  * Back in the browser, navigate to the newly visible `Administration` link on the top navbar
-  * Click `Administrative Sets` on the left hand navigation menu
-  * Create a new admin set, feel free to name it whatever you want, and click save
-  * After saving your new set, click the `Workflow`
-  * Select the `Default Workflow` and click save
-
-  Now you can use the application normally
+   * Start the test stack `devstack -t up arch`
+   * Run the seed task for the test environmenbt: `bundle exec rake arch:seed RAILS_ENV=test`
+   * Run the test suite: `bundle exec rspec`
 
  ## Deploying
   * Submit a PR in github to the environment's deploy branch that you're targeting

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -23,8 +23,6 @@
             <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
-        <!-- Embargo hidden 9/13/2017 as it doesn't work in Hyrax 1.x -->
-        <!--
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
@@ -39,7 +37,6 @@
             </div>
           </label>
         </li>
-        -->
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>


### PR DESCRIPTION
Fixes #343

* Re-enable the embargo radio button in the work form
* Also adds current developer installation/setup instructions to the README
