### PR TITLE
Remove /var/log/puma and just log to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,7 @@ COPY --chown=app:staff --from=base /usr/local/bundle /usr/local/bundle
 COPY --chown=app:app --from=base /home/app/current/vendor/gems/ /home/app/current/vendor/gems/
 COPY --chown=app:app . /home/app/current/
 
-RUN mkdir /var/log/puma && chown root:app /var/log/puma && chmod 0775 /var/log/puma && \
-    mkdir /var/run/puma && chown root:app /var/run/puma && chmod 0775 /var/run/puma
+RUN mkdir /var/run/puma && chown root:app /var/run/puma && chmod 0775 /var/run/puma
 
 USER app
 WORKDIR /home/app/current

--- a/config/puma_container.rb
+++ b/config/puma_container.rb
@@ -3,7 +3,6 @@ threads 8, 32
 workers `grep -c processor /proc/cpuinfo`
 port ENV.fetch('PORT') { 3000 }
 pidfile '/var/run/puma/puma.pid'
-stdout_redirect '/var/log/puma/puma.log', '/var/log/puma/puma.log', true
 daemonize false
 preload_app!
 on_worker_boot do


### PR DESCRIPTION
Just let puma write to stdout instead of logging to a file inside the container