### PR TITLE
Fix failing tests on Travis

### DIFF
--- a/.docker-stack/nufia7-development/docker-compose.yml
+++ b/.docker-stack/nufia7-development/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
   minio:
 services:
   fedora:
-    image: nulib/fcrepo4
+    image: nulib/fcrepo4:4.7.5
     volumes:
     - fedora:/data
     ports:

--- a/.docker-stack/nufia7-test/docker-compose.yml
+++ b/.docker-stack/nufia7-test/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
   minio:
 services:
   fedora:
-    image: nulib/fcrepo4
+    image: nulib/fcrepo4:4.7.5
     volumes:
     - fedora:/data
     ports:


### PR DESCRIPTION
Docker was using `nulib/fcrepo4:latest` for its tests, and that is now Fedora 5.0.0. This PR pins the dev/test Fedora container to `nulib/fcrepo:4.7.5`.