### PR TITLE
Add a submit a work link in main navigation

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -95,10 +95,7 @@
         </ul>
         <!-- from #quick-links -->
         <ul id="mobile-nav-bottom-right">
-          <li><%= link_to t('Browse'), main_app.search_catalog_path %></li>
-          <li><%= link_to t(:'hyrax.controls.about'), hyrax.about_path %></li>
-          <li><%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
-          <li><%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path %></li>
+          <%= render 'nu_partials/main_nav' %>
         </ul>
       </div>
     </nav>
@@ -122,10 +119,7 @@
 <nav id="top-nav" class="narrow-dropdown" aria-label="main navigation menu">
     <div class="contain-1120">
         <ul>
-          <li><%= link_to t('Browse'), main_app.search_catalog_path %></li>
-          <li><%= link_to t(:'hyrax.controls.about'), hyrax.about_path %></li>
-          <li><%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
-          <li><%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path %></li>
+          <%= render 'nu_partials/main_nav' %>
         </ul>
     </div>
 </nav>

--- a/app/views/nu_partials/_main_nav.html.erb
+++ b/app/views/nu_partials/_main_nav.html.erb
@@ -1,0 +1,21 @@
+<li>
+    <% if signed_in? %>
+      <% if create_work_presenter.many? %>
+        <%= link_to '#', data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
+          <%= t('hyrax.buttons.submit_a_work') %>
+        <% end %>
+      <% else # simple link to the first work type %>
+        <%= link_to new_polymorphic_path([main_app, create_work_presenter.first_model]) do %>
+          <%= t('hyrax.buttons.submit_a_work') %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= link_to hyrax.dashboard_path do %>
+        <%= t('hyrax.buttons.submit_a_work') %>
+      <% end %>
+    <% end %>
+</li>
+<li><%= link_to t('Browse'), main_app.search_catalog_path %></li>
+<li><%= link_to t(:'hyrax.controls.about'), hyrax.about_path %></li>
+<li><%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
+<li><%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   hyrax:
     buttons:
       get_started: "Get Started"
+      submit_a_work: "Submit a work"
     product_name: "Repository | institutional"
     institution_name_full: "Northwestern University"
     institution_name: "NU"


### PR DESCRIPTION
Fixes #588 

@chrisdaaz @davidschober 

Looks like:

<img width="986" alt="main-nav-submit-a-work" src="https://user-images.githubusercontent.com/3020266/51267623-c6e7c900-1983-11e9-86fd-a0f8e55cf32b.png">
