### PR TITLE
Apply NU Global marketing font families to the Hyrax application

### DIFF
--- a/app/assets/stylesheets/arch/abstracts/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/arch/abstracts/_bootstrap_variables.scss
@@ -4,4 +4,6 @@ $dropdown-link-hover-color: $nu-purple;
 $dropdown-link-hover-bg: $nu-purple-30;
 $dropdown-header-color: $nu-purple-30;
 
-// Navs
+// Fonts
+$font-family-sans-serif: $AkkuratProRegular;
+$headings-font-family: $CamptonBold;

--- a/app/assets/stylesheets/arch/base/_hyrax_overrides.scss
+++ b/app/assets/stylesheets/arch/base/_hyrax_overrides.scss
@@ -33,3 +33,7 @@ li.attribute.status {
     display: none;
   }
 }
+
+h4, h5 {
+  font-family: $AkkuratProRegular;
+}


### PR DESCRIPTION
Fixes #582 

@chrisdaaz @davidschober Have a look at this and let me know when it's up on staging.   I applied the following:

1. NU Global marketing font (Akkurat Pro Regular) to everything;
2. NU Global marketing's heading font where they use it (Campton Book Bold)

Part of me thinks the heading, Campton Book Bold font looks better, and part of me thinks it's kind of messy.  Figured get your opinions.  Easy to turn on/off now.