### PR TITLE
Add recaptcha to contact form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'config'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 gem 'omniauth-openam'
+gem 'recaptcha'
 gem 'rsolr', '~> 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1370,6 +1370,8 @@ GEM
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
     rdoc (4.3.0)
+    recaptcha (4.13.1)
+      json
     redic (1.5.1)
       hiredis
     redis (4.1.0)
@@ -1602,6 +1604,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.6)
   rb-readline
+  recaptcha
   redis-rails
   rsolr (~> 2.0)
   rspec-rails (~> 3.6)

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,0 +1,54 @@
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<h1>
+  <%= t('hyrax.contact_form.header') %>
+</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                            html: { class: 'form-horizontal' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
+    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
+    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= recaptcha_tags %>
+  </div>
+
+  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
+<% end %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+Recaptcha.configure do |config|
+  config.site_key = Settings.recaptcha&.site_key
+  config.secret_key = Settings.recaptcha&.secret_key
+  # Uncomment the following line if you are using a proxy server:
+  # config.proxy = 'http://myproxy.com.au:8080'
+end


### PR DESCRIPTION
Fixes #556 

For local testing add to `config/settings/development.local.yml`:

```
recaptcha:
  site_key: 'putthesitekeyhere'
  secret_key: 'putthesecretkeyhere'
```

Reminder: Update with new API key before deploy to prod... #600