### PR TITLE
Update to licenses and rights statements

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -13,4 +13,6 @@
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+<%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
+
 

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -22,7 +22,7 @@ terms:
       active: false
     - id: http://rightsstatements.org/page/InC/1.0/?language=en
       term: In Copyright
-      active: true
+      active: false
     - id: https://creativecommons.org/licenses/by/4.0/
       term: Creative Commons BY Attribution 4.0 International
       active: true


### PR DESCRIPTION
Fixes #577 


* Show `license` on the Work show page if a value(s) exist for it.
* Remove 'In Copyright' (`http://rightsstatements.org/page/InC/1.0/?language=en`) as an active value for license option.