### PR TITLE
Thumbnail_id and doi citation in head

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
 ## Developer Installation
 
   * Clone this repository `git clone git@github.com:nulib/institutional-repository.git`
+  * Grab the development environment configs from the `miscellany` repo: `arch/config/settings/development.local.yml` and save to `config/settings/development.local.yml` inside the project.
   * From inside the project directory run `bundle install`
   * Start the docker stack with `devstack up arch`
   * From inside the project directory run `bundle exec rake arch:seed`
      * You can include the optional arguments to create an admin user (such as yourself). Ex: `bundle exec rake arch:seed ADMIN_USER=your_netid ADMIN_EMAIL=your_email@northwestern.edu`
   * In a separate tab, start the rails server `bundle exec rails server`
+  * You can see the app in a browser at http://devbox.library.northwestern.edu
 
   ## Running the tests
 
@@ -36,5 +38,6 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
    * Run the test suite: `bundle exec rspec`
 
  ## Deploying
-  * Submit a PR in github to the environment's deploy branch that you're targeting
-    For example, to deploy to staging submit a PR to `deploy/staging`
+  * Submit a PR in github to the environment's deploy branch
+     * To deploy to staging submit a PR to `deploy/staging`
+     * To deploy to production submit a PR to `master`

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,2 +1,3 @@
 <!-- File Override: gem file 'sufia-7.3.0/app/views/_head_tag_extras.erb' -->
+<meta name="citation_doi" content="<%= @presenter.doi %>">
 <%= favicon_link_tag %>

--- a/app/views/hyrax/base/show.json.jbuilder
+++ b/app/views/hyrax/base/show.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! @curation_concern, *[:id, :member_of_collections] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
+json.extract! @curation_concern, *[:id, :member_of_collections, :thumbnail_id] + @curation_concern.class.fields.reject { |f| [:has_model].include? f }
 json.version @curation_concern.etag


### PR DESCRIPTION
* Adds `thumbnail_id` to a work's Blacklight JSON endpoint
* Adds DOI citation in head content of work page
* Updates Readme with developer configuration info

Fixes https://github.com/nulib/institutional-repository/issues/669
Fixes https://github.com/nulib/institutional-repository/issues/654

