### PR TITLE
Unlink DOI

### DIFF
--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -3,6 +3,10 @@
 module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
     def doi
+      solr_document.doi.first unless solr_document.doi.empty?
+    end
+
+    def doi_link
       "https://doi.org/#{solr_document.doi.first.split(':').last}" unless solr_document.doi.empty?
     end
 

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,3 +1,5 @@
 <!-- File Override: gem file 'sufia-7.3.0/app/views/_head_tag_extras.erb' -->
-<meta name="citation_doi" content="<%= @presenter.doi %>">
+<% if (@presenter.class.method_defined?(:doi_link)) %>
+<meta name="citation_doi" content="<%= @presenter.doi_link %>">
+<% end %>
 <%= favicon_link_tag %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,7 +1,7 @@
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:doi, html_dl: true) %>
+<%= presenter.attribute_to_html(:doi, html_dl: true, label: 'DOI') %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>

--- a/spec/features/show_generic_work_spec.rb
+++ b/spec/features/show_generic_work_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Display a musical work' do
       visit(hyrax_generic_work_path(work.id))
       expect(page).to have_content('Creator 1')
       expect(page).to have_content('work title')
-      expect(page).to have_content('https://doi.org/test_doi')
+      expect(page).to have_content('doi:test_doi')
     end
   end
 end

--- a/spec/presenters/hyrax/generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/generic_work_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::GenericWorkPresenter do
 
     describe '#doi' do
       it 'returns the doi' do
-        expect(presenter.doi).to eq('https://doi.org/test_doi')
+        expect(presenter.doi).to eq('test_doi')
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/nulib/institutional-repository/issues/652

* Fixes issue that previous PR to fix ( https://github.com/nulib/institutional-repository/issues/654 ) caused. `_head_tag_extras.html.erb` is included on all pages and not all presenters have `doi` properties.
* Unlinks the DOI on the work show page
* Capitalizes DOI in the label on the work show page 