### PR TITLE
Unlink Indentifier and revert DOI link change

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,7 +81,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('rights', :stored_searchable), helper_method: :license_links
     config.add_index_field solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('resource_type', :facetable)
     config.add_index_field solr_name('file_format', :stored_searchable), link_to_search: solr_name('file_format', :facetable)
-    config.add_index_field solr_name('identifier', :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
+    config.add_index_field solr_name('identifier', :stored_searchable), field_name: 'identifier'
     config.add_index_field solr_name('embargo_release_date', :stored_sortable, type: :date), label: 'Embargo release date', helper_method: :human_readable_date
     config.add_index_field solr_name('lease_expiration_date', :stored_sortable, type: :date), label: 'Lease expiration date', helper_method: :human_readable_date
     config.add_index_field solr_name('doi', :stored_sortable)

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -3,10 +3,6 @@
 module Hyrax
   class GenericWorkPresenter < Hyrax::WorkShowPresenter
     def doi
-      solr_document.doi.first unless solr_document.doi.empty?
-    end
-
-    def doi_link
       "https://doi.org/#{solr_document.doi.first.split(':').last}" unless solr_document.doi.empty?
     end
 

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,5 +1,5 @@
 <!-- File Override: gem file 'sufia-7.3.0/app/views/_head_tag_extras.erb' -->
-<% if (@presenter.class.method_defined?(:doi_link)) %>
-<meta name="citation_doi" content="<%= @presenter.doi_link %>">
+<% if (@presenter.class.method_defined?(:doi)) %>
+<meta name="citation_doi" content="<%= @presenter.doi %>">
 <% end %>
 <%= favicon_link_tag %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -5,7 +5,7 @@
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>

--- a/spec/features/show_generic_work_spec.rb
+++ b/spec/features/show_generic_work_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Display a musical work' do
     GenericWork.new.tap do |work|
       work.creator = ['Creator 1']
       work.title = ['work title']
-      work.doi = 'doi:test_doi'
+      work.doi = 'test_doi'
       work.apply_depositor_metadata('user')
       work.visibility = 'open'
       work.save
@@ -18,7 +18,7 @@ RSpec.feature 'Display a musical work' do
       visit(hyrax_generic_work_path(work.id))
       expect(page).to have_content('Creator 1')
       expect(page).to have_content('work title')
-      expect(page).to have_content('doi:test_doi')
+      expect(page).to have_content('https://doi.org/test_doi')
     end
   end
 end

--- a/spec/presenters/hyrax/generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/generic_work_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::GenericWorkPresenter do
 
     describe '#doi' do
       it 'returns the doi' do
-        expect(presenter.doi).to eq('test_doi')
+        expect(presenter.doi).to eq('https://doi.org/test_doi')
       end
     end
   end


### PR DESCRIPTION

* Revert changes I made that changed the format and unlinked the DOI
* Unlink the Identifier field from kicking off a catalog search, though if it's an external link it will still link externally from the show page