### PR TITLE
Complete proquest ingest work: depositors & descriptions

### DIFF
--- a/app/lib/proquest/metadata.rb
+++ b/app/lib/proquest/metadata.rb
@@ -15,10 +15,10 @@ class Proquest::Metadata
 
     def work_attributes
       {
-        admin_set_id: @admin_set_id,
+        admin_set_id: AdminSet::DEFAULT_ID,
         creator: creators,
         date_uploaded: today,
-        depositor: Settings.dissertation_depositor,
+        depositor: Settings.proquest.dissertation_depositor,
         description: description,
         embargo_release_date: embargo_release_date,
         identifier: identifier,
@@ -31,7 +31,7 @@ class Proquest::Metadata
         visibility_after_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
         visibility_during_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
         visibility: visibility
-      }.reject! { |_k, v| v.blank? }
+      }.compact
     end
 
     def file_list
@@ -62,7 +62,7 @@ class Proquest::Metadata
     end
 
     def description
-      metadata.xpath('//DISS_content/DISS_abstract/DISS_para').map { |description| description.text.strip }
+      Array(metadata.xpath('//DISS_content/DISS_abstract/DISS_para').map(&:text).join(' '))
     end
 
     def identifier

--- a/spec/fixtures/files/proquest/northwestern_0000_DATA_embargo_code_0.xml
+++ b/spec/fixtures/files/proquest/northwestern_0000_DATA_embargo_code_0.xml
@@ -109,7 +109,8 @@
   </DISS_description>
   <DISS_content>
     <DISS_abstract>
-      <DISS_para>Lorem ipsum dolor sit amet</DISS_para>
+      <DISS_para>Lorem ipsum.</DISS_para>
+      <DISS_para>Dolor sit amet.</DISS_para>
     </DISS_abstract>
     <DISS_supp_abstract/>
     <DISS_binary type="PDF">test_0000.pdf</DISS_binary>

--- a/spec/lib/proquest/metadata_spec.rb
+++ b/spec/lib/proquest/metadata_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe Proquest::Metadata do
       let(:record) { described_class.new(xml, today) }
 
       it 'extracts metadata (without an embargo) and file list' do
-        expect(record.proquest_metadata).to eq([{ creator: ['Last, First Middle'],
+        expect(record.proquest_metadata).to eq([{ admin_set_id: AdminSet::DEFAULT_ID,
+                                                  creator: ['Last, First Middle'],
                                                   date_uploaded: today,
-                                                  description: ['Lorem ipsum dolor sit amet'],
+                                                  depositor: 'registered',
+                                                  description: ['Lorem ipsum. Dolor sit amet.'],
                                                   identifier: ['http://dissertations.umi.com/northwestern:12345', 'proquest'],
                                                   keyword: ['keyword1', 'keyword2'],
                                                   language: ['en'],

--- a/spec/lib/proquest/package_spec.rb
+++ b/spec/lib/proquest/package_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Proquest::Package do
   let(:package) { Aws::S3::Object.new(client: Aws::S3::Client.new, bucket_name: Settings.aws.buckets.proquest, key: File.basename(zip)) }
 
   before do
+    AdminSet.find_or_create_default_admin_set_id
     User.find_or_create_by(username: 'registered')
     package.upload_file(zip)
   end


### PR DESCRIPTION
Fixes #684 

- Combines abstract paragraphs into one description because separate descriptions are not guaranteed to be shown in the order in which they were created.
- Use the correct config `Settings.proquest.dissertation_depositor` for the work depositor.
- Make tests pass.
