### PR TITLE
Move completed Proquest packages to '_completed/'

### DIFF
--- a/app/jobs/proquest_ingest_bucket_job.rb
+++ b/app/jobs/proquest_ingest_bucket_job.rb
@@ -2,7 +2,7 @@ class ProquestIngestBucketJob < ApplicationJob
   # @param [Aws::S3::Bucket] bucket
   def perform(bucket)
     bucket.objects.each do |obj|
-      ProquestIngestPackageJob.perform_later(bucket.name, obj.key) if obj.key.ends_with?('.zip')
+      ProquestIngestPackageJob.perform_later(bucket.name, obj.key) if obj.key.ends_with?('.zip') && !obj.key.starts_with?('_completed/')
     end
     true
   rescue StandardError => e

--- a/app/lib/proquest/package.rb
+++ b/app/lib/proquest/package.rb
@@ -19,6 +19,8 @@ class Proquest::Package
                       resource: metadata.merge(title: [f]),
                       f: file_path)
     end
+    s3_package.copy_to(bucket: s3_package.bucket.name, key: "_completed/#{s3_package.key}", multipart_copy: s3_package.size > 5.megabytes)
+    s3_package.delete
   end
 
   private


### PR DESCRIPTION
- Moves zip package to `_completed/[zip package]` in the same bucket
- ProquestIngestBucketJob skips anything in `_completed/`'