### PR TITLE
Change http to https in resource sync links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,5 @@
 GIT
-  remote: https://github.com/nulib/active-elastic-job.git
-  revision: 09f50bc0ab20d4a4dd0dd8ffb6e3d12f9a694bd8
-  branch: latest-aws-sdk
-  specs:
-    active_elastic_job (2.0.1)
-      aws-sdk-sqs (~> 1)
-      rails (>= 4.2)
-
-GIT
-  remote: https://github.com/nulib/hydra-derivatives.git
-  revision: fbc325db8fa5f1e87172d7e83aa792ccf07b9ee4
-  branch: vips
-  specs:
-    hydra-derivatives (3.4.1)
-      active-fedora (>= 11.3.1, < 13)
-      active_encode (~> 0.1)
-      activesupport (>= 4.0, < 6)
-      addressable (~> 2.5)
-      deprecation
-      mime-types (> 2.0, < 4.0)
-      mini_magick (>= 3.2, < 5)
-      ruby-vips
-
-GIT
-  remote: https://github.com/nulib/hyrax.git
+  remote: git://github.com/nulib/hyrax.git
   revision: 8426687f988de4191e797408fa60c481e05f09b6
   branch: 2.4.1-plus-be
   specs:
@@ -75,6 +51,30 @@ GIT
       signet
       simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
+
+GIT
+  remote: https://github.com/nulib/active-elastic-job.git
+  revision: 09f50bc0ab20d4a4dd0dd8ffb6e3d12f9a694bd8
+  branch: latest-aws-sdk
+  specs:
+    active_elastic_job (2.0.1)
+      aws-sdk-sqs (~> 1)
+      rails (>= 4.2)
+
+GIT
+  remote: https://github.com/nulib/hydra-derivatives.git
+  revision: fbc325db8fa5f1e87172d7e83aa792ccf07b9ee4
+  branch: vips
+  specs:
+    hydra-derivatives (3.4.1)
+      active-fedora (>= 11.3.1, < 13)
+      active_encode (~> 0.1)
+      activesupport (>= 4.0, < 6)
+      addressable (~> 2.5)
+      deprecation
+      mime-types (> 2.0, < 4.0)
+      mini_magick (>= 3.2, < 5)
+      ruby-vips
 
 GEM
   remote: https://rubygems.org/
@@ -138,8 +138,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    almond-rails (0.1.0)
-      rails (>= 4.2, < 6)
+    almond-rails (0.3.0)
+      rails (>= 4.2)
     arel (8.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.6.1)
@@ -1235,7 +1235,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     oauth (0.5.4)
-    oauth2 (1.4.2)
+    oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
@@ -1392,7 +1392,7 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
-    redlock (1.1.0)
+    redlock (1.2.0)
       redis (>= 3.0.0, < 5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -1531,7 +1531,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    tinymce-rails (4.9.7)
+    tinymce-rails (4.9.8)
       railties (>= 3.1.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
 ## Running the tests
 
 - Start the test stack `devstack -t up arch`
-- Run the seed task for the test environmenbt: `bundle exec rake arch:seed RAILS_ENV=test`
+- Run the seed task for the test environment: `bundle exec rake arch:seed RAILS_ENV=test`
 - Run the test suite: `bundle exec rspec`
 
 ## Deploying

--- a/app/controllers/hyrax/resource_sync_controller.rb
+++ b/app/controllers/hyrax/resource_sync_controller.rb
@@ -1,0 +1,52 @@
+class Hyrax::ResourceSyncController < ApplicationController
+  # We don't need locale here
+  def default_url_options
+    super.except(:locale)
+  end
+
+  def source_description
+    render_from_cache_as_xml(:source_description)
+  end
+
+  def capability_list
+    render_from_cache_as_xml(:capability_list)
+  end
+
+  def change_list
+    render_from_cache_as_xml(:change_list)
+  end
+
+  def resource_list
+    render_from_cache_as_xml(:resource_list)
+  end
+
+  private
+
+    def build_change_list
+      Hyrax::ResourceSync::ChangeListWriter.new(capability_list_url: hyrax.capability_list_url(protocol: 'https'),
+                                                resource_host: request.host).write
+    end
+
+    def build_resource_list
+      Hyrax::ResourceSync::ResourceListWriter.new(capability_list_url: hyrax.capability_list_url(protocol: 'https'),
+                                                  resource_host: request.host).write
+    end
+
+    def build_capability_list
+      Hyrax::ResourceSync::CapabilityListWriter.new(resource_list_url: hyrax.resource_list_url(protocol: 'https'),
+                                                    change_list_url: hyrax.change_list_url(protocol: 'https'),
+                                                    description_url: hyrax.source_description_url(protocol: 'https')).write
+    end
+
+    def build_source_description
+      Hyrax::ResourceSync::SourceDescriptionWriter.new(capability_list_url: hyrax.capability_list_url(protocol: 'https')).write
+    end
+
+    def render_from_cache_as_xml(resource_sync_type)
+      # Caching based on host, for multi-tenancy support
+      body = Rails.cache.fetch("#{resource_sync_type}_#{request.host}", expires_in: 1.week) do
+        send("build_#{resource_sync_type}")
+      end
+      render body: body, content_type: 'application/xml'
+    end
+end

--- a/lib/hyrax/resource_sync/capability_list_writer.rb
+++ b/lib/hyrax/resource_sync/capability_list_writer.rb
@@ -1,0 +1,40 @@
+module Hyrax
+  module ResourceSync
+    class CapabilityListWriter
+      attr_reader :resource_list_url, :change_list_url, :description_url
+      def initialize(resource_list_url:, change_list_url:, description_url:)
+        @resource_list_url = resource_list_url
+        @change_list_url = change_list_url
+        @description_url = description_url
+      end
+
+      def write
+        builder.to_xml
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      private
+
+        def builder
+          Nokogiri::XML::Builder.new do |xml|
+            xml.urlset('xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+                       'xmlns:rs' => 'http://www.openarchives.org/rs/terms/') do
+              xml['rs'].ln(rel: 'up', href: description_url)
+              xml['rs'].md(capability: 'capabilitylist')
+
+              xml.url do
+                xml.loc resource_list_url
+                xml['rs'].md(capability: 'resourcelist')
+              end
+
+              xml.url do
+                xml.loc change_list_url
+                xml['rs'].md(capability: 'changelist')
+              end
+            end
+          end
+        end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/lib/hyrax/resource_sync/change_list_writer.rb
+++ b/lib/hyrax/resource_sync/change_list_writer.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module ResourceSync
+    # TODO: the big assumption I'm making here is that the repository has fewer
+    # than 50,000 resources to list. The Sitemap protocol is limited at 50,000
+    # items, so if we require more than that, we must have multiple Change
+    # lists and add a Change List Index to point to all of them.
+    class ChangeListWriter
+      attr_reader :resource_host, :capability_list_url
+      MODIFIED_DATE_FIELD = 'system_modified_dtsi'
+      BEGINNING_OF_TIME = '1970-01-01T00:00:00Z'
+
+      def initialize(resource_host:, capability_list_url:)
+        @resource_host = resource_host
+        @capability_list_url = capability_list_url
+      end
+
+      def write
+        builder.to_xml
+      end
+
+      private
+
+        def builder
+          Nokogiri::XML::Builder.new do |xml|
+            xml.urlset('xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+                       'xmlns:rs' => 'http://www.openarchives.org/rs/terms/') do
+              xml['rs'].ln(rel: 'up', href: capability_list_url, protocol: 'https')
+              xml['rs'].md(capability: 'changelist', from: from)
+              build_changes(xml)
+            end
+          end
+        end
+
+        # return the earliest change. Otherwise BEGINNING_OF_TIME
+        def from
+          @from ||= begin
+                      results = relation.search_with_conditions(public_access, rows: 1, sort: MODIFIED_DATE_FIELD + ' asc')
+                      if results.present?
+                        results.first.fetch(MODIFIED_DATE_FIELD)
+                      else
+                        BEGINNING_OF_TIME
+                      end
+                    end
+        end
+
+        def sort
+          { sort: MODIFIED_DATE_FIELD + ' desc' }
+        end
+
+        def relation
+          @relation ||= Hyrax::ExposedModelsRelation.new
+        end
+
+        def build_changes(xml)
+          relation.search_in_batches(public_access, sort) do |doc_set|
+            build_resources(xml, doc_set)
+          end
+        end
+
+        def build_resources(xml, doc_set)
+          doc_set.each do |doc|
+            model = doc.fetch('has_model_ssim', []).first.constantize
+            if model == Collection
+              build_resource(xml, doc, model, hyrax_routes)
+            else
+              build_resource(xml, doc, model, main_app_routes)
+            end
+          end
+        end
+
+        # @param xml [Nokogiri::XML::Builder]
+        # @param doc [Hash]
+        # @param routes [Module] has the routes for the object
+        def build_resource(xml, doc, model, routes)
+          modified_date = doc.fetch('system_modified_dtsi')
+          created_date = doc.fetch('system_create_dtsi')
+          xml.url do
+            key = model.model_name.singular_route_key
+            xml.loc routes.send(key + '_url', doc['id'], host: resource_host, protocol: 'https')
+            xml.lastmod modified_date
+            xml['rs'].md(change: modified_date == created_date ? 'created' : 'updated')
+          end
+        end
+
+        def main_app_routes
+          Rails.application.routes.url_helpers
+        end
+
+        def hyrax_routes
+          Hyrax::Engine.routes.url_helpers
+        end
+
+        delegate :collection_url, to: :routes
+
+        def public_access
+          { Hydra.config.permissions.read.group => 'public' }
+        end
+    end
+  end
+end

--- a/lib/hyrax/resource_sync/resource_list_writer.rb
+++ b/lib/hyrax/resource_sync/resource_list_writer.rb
@@ -1,0 +1,84 @@
+module Hyrax
+  module ResourceSync
+    # TODO: the big assumption I'm making here is that the repository has fewer
+    # than 50,000 resources to list. The Sitemap protocol is limited at 50,000
+    # items, so if we require more than that, we must have multiple Resource
+    # lists and add a Resource List Index to point to all of them.
+    class ResourceListWriter
+      attr_reader :resource_host, :capability_list_url
+
+      def initialize(resource_host:, capability_list_url:)
+        @resource_host = resource_host
+        @capability_list_url = capability_list_url
+      end
+
+      def write
+        builder.to_xml
+      end
+
+      private
+
+        def builder
+          Nokogiri::XML::Builder.new do |xml|
+            xml.urlset('xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+                       'xmlns:rs' => 'http://www.openarchives.org/rs/terms/') do
+              xml['rs'].ln(rel: 'up', href: capability_list_url)
+              xml['rs'].md(capability: 'resourcelist', at: Time.now.utc.iso8601)
+              build_collections(xml)
+              build_works(xml)
+              build_files(xml)
+            end
+          end
+        end
+
+        def build_collections(xml)
+          Collection.search_in_batches(public_access) do |doc_set|
+            build_resources(xml, doc_set, hyrax_routes)
+          end
+        end
+
+        def build_works(xml)
+          Hyrax::WorkRelation.new.search_in_batches(public_access) do |doc_set|
+            build_resources(xml, doc_set, main_app_routes)
+          end
+        end
+
+        def build_files(xml)
+          ::FileSet.search_in_batches(public_access) do |doc_set|
+            build_resources(xml, doc_set, main_app_routes)
+          end
+        end
+
+        def build_resources(xml, doc_set, routes)
+          doc_set.each do |doc|
+            build_resource(xml, doc, routes)
+          end
+        end
+
+        # @param xml [Nokogiri::XML::Builder]
+        # @param doc [Hash]
+        # @param routes [Module] has the routes for the object
+        def build_resource(xml, doc, routes)
+          xml.url do
+            key = doc.fetch('has_model_ssim', []).first.constantize.model_name.singular_route_key
+            xml.loc routes.send(key + '_url', doc['id'], host: resource_host, protocol: 'https')
+            xml.lastmod doc['system_modified_dtsi']
+          end
+        end
+
+        def main_app_routes
+          Rails.application.routes.url_helpers
+        end
+
+        def hyrax_routes
+          Hyrax::Engine.routes.url_helpers
+        end
+
+        delegate :collection_url, to: :routes
+
+        def public_access
+          { Hydra.config.permissions.read.group => 'public' }
+        end
+    end
+  end
+end


### PR DESCRIPTION
Brought in overrides to Hyrax in order to change http to https in resource sync links


Test by going to (you may have to clear cache): 
https://arch.stack.rdc-staging.library.northwestern.edu/resourcelist
https://arch.stack.rdc-staging.library.northwestern.edu/.well-known/resourcesync
https://arch.stack.rdc-staging.library.northwestern.edu/capabilitylist
https://arch.stack.rdc-staging.library.northwestern.edu/changelist



***Reminder***: Clear Rails cache on deploy (if needed)....
Production: 
`Rails.cache.delete("resource_list_arch.library.northwestern.edu")`

Current behavior: 


<img width="598" alt="Screen Shot 2020-03-19 at 2 08 10 PM" src="https://user-images.githubusercontent.com/6372022/77105200-3bd0eb80-69eb-11ea-8a50-f7e6af9087ec.png">

-------------------------------
Fixed behavior: 

<img width="895" alt="Screen Shot 2020-03-19 at 2 08 15 PM" src="https://user-images.githubusercontent.com/6372022/77105207-3e334580-69eb-11ea-8d0b-c7e0c6d044f2.png">



