### PR TITLE
Tell CircleCI to build/deploy master branch to prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ workflows:
             branches:
               only:
                 - /^build-.+/
+                - master
                 - /^deploy\/.+/
       - deploy:
           requires:


### PR DESCRIPTION
The last update to the CircleCI config file left out the directive to build on pushes to master. This PR fixes that.