### PR TITLE
Update omniauth-nusso to v0.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'config'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 gem 'honeybadger', '~> 4.0'
-gem 'omniauth-nusso', '>= 0.1.2'
+gem 'omniauth-nusso', '>= 0.1.3'
 gem 'recaptcha'
 gem 'rsolr', '~> 2.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1244,7 +1244,7 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-nusso (0.1.2)
+    omniauth-nusso (0.1.3)
       faraday
       omniauth
     openseadragon (0.5.0)
@@ -1599,7 +1599,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   lograge
-  omniauth-nusso (>= 0.1.2)
+  omniauth-nusso (>= 0.1.3)
   pg (~> 0.21)
   pry-byebug
   pry-rails


### PR DESCRIPTION
Updating omniauth-nusso to 0.1.3 will prevent JSON parsing errors from directory search responses. See nulib/omniauth-nusso#1 for more information.