### PR TITLE
Use new local https endpoint for AWS config

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,7 +4,7 @@ localstack:
 active_job:
   queue_adapter: inline
 aws:
-  endpoint: http://localhost:9001
+  endpoint: https://devbox.library.northwestern.edu:9001
   buckets:
     archives: dev-archives
     dropbox: dev-dropbox


### PR DESCRIPTION
Minio now runs at `https://devbox.library.northwestern.edu:9001`, updates the `development.yml` accordingly.