### PR TITLE
Use the Fedora create_date as the DOI publicationYear

### DIFF
--- a/app/services/doi_minting_service.rb
+++ b/app/services/doi_minting_service.rb
@@ -64,7 +64,7 @@ class DoiMintingService
         titles: titles,
         publisher: publishers,
         dates: [dates_created].flatten,
-        publicationYear: dates_created.first[:date],
+        publicationYear: work.create_date.year,
         types: resource_type,
         url: url
       )


### PR DESCRIPTION
Fixes #736; refs #715 

DataCite's DOI update API was preventing draft DOIs from being published without a `publicationYear` attribute. We have updated the DOI minting service to use the 4-digit year from Fedora's `date_created` element as the DOI `publicationYear`.