### PR TITLE
Remove alternate_identifier Dataset property, set identifier label to 'Alternate Identifier'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,10 @@ gem 'docker-stack'
 
 gem 'zk'
 
+group :development do
+  gem 'web-console'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -854,6 +854,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     blacklight (6.19.2)
@@ -1551,6 +1552,11 @@ GEM
     unicode-display_width (1.4.1)
     warden (1.2.8)
       rack (>= 2.0.6)
+    web-console (3.7.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -1621,6 +1627,7 @@ DEPENDENCIES
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
+  web-console
   webmock
   xray-rails
   yaml_db

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,11 +81,10 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('rights', :stored_searchable), helper_method: :license_links
     config.add_index_field solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: solr_name('resource_type', :facetable)
     config.add_index_field solr_name('file_format', :stored_searchable), link_to_search: solr_name('file_format', :facetable)
-    config.add_index_field solr_name('identifier', :stored_searchable), field_name: 'identifier'
+    config.add_index_field solr_name('identifier', :stored_searchable), label: 'Alternate Identifier', field_name: 'identifier'
     config.add_index_field solr_name('embargo_release_date', :stored_sortable, type: :date), label: 'Embargo release date', helper_method: :human_readable_date
     config.add_index_field solr_name('lease_expiration_date', :stored_sortable, type: :date), label: 'Lease expiration date', helper_method: :human_readable_date
     config.add_index_field solr_name('doi', :stored_sortable)
-    config.add_index_field solr_name('alternate_identifier', :stored_sortable), label: 'Alternate Identifier'
     config.add_index_field solr_name('contact_information', :stored_sortable), label: 'Contact Information'
     config.add_index_field solr_name('related_citation', :stored_sortable), label: 'Related Citation'
 

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   # Generated form for Dataset
   class DatasetForm < Hyrax::Forms::WorkForm
     self.model_class = ::Dataset
-    self.terms += [:alternate_identifier, :bibliographic_citation, :contact_information, :related_citation, :resource_type]
+    self.terms += [:bibliographic_citation, :contact_information, :related_citation, :resource_type]
     self.required_fields += [:date_created, :description, :license]
     self.required_fields -= [:keyword, :rights_statement]
   end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -16,10 +16,6 @@ class Dataset < ActiveFedora::Base
   DEFAULT_PUBLISHER = 'Northwestern University'.freeze
   DEFAULT_RESOURCE_TYPE = Qa::Authorities::Local.subauthority_for('resource_types').find('Dataset').fetch('id').freeze
 
-  property :alternate_identifier, predicate: ::RDF::URI('https://www.library.northwestern.edu/terms#alternateIdentifier') do |index|
-    index.as :stored_searchable
-  end
-
   property :contact_information, predicate: ::RDF::Vocab::DCAT.contactPoint do |index|
     index.as :stored_searchable
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,10 +25,6 @@ class SolrDocument
   # Do content negotiation for AF models.
   use_extension(Hydra::ContentNegotiation)
 
-  def alternate_identifier
-    fetch(Solrizer.solr_name('alternate_identifier', :stored_searchable), [])
-  end
-
   def bibliographic_citation
     fetch(Solrizer.solr_name('bibliographic_citation', :stored_searchable), [])
   end

--- a/app/presenters/hyrax/dataset_presenter.rb
+++ b/app/presenters/hyrax/dataset_presenter.rb
@@ -2,7 +2,7 @@
 #  `rails generate hyrax:work Dataset`
 module Hyrax
   class DatasetPresenter < Hyrax::WorkShowPresenter
-    delegate :alternate_identifier, :bibliographic_citation, :contact_information, :doi, :related_citation, to: :solr_document
+    delegate :bibliographic_citation, :contact_information, :doi, :related_citation, to: :solr_document
 
     def public_member_presenters
       @public_member_presenters ||= file_set_presenters.find_all do |m|

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -6,7 +6,7 @@
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, html_dl: true, label: 'Alternate Identifier') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>

--- a/config/locales/dataset.en.yml
+++ b/config/locales/dataset.en.yml
@@ -6,3 +6,7 @@ en:
       dataset:
         description:        "Research data that was prepared in support of formal publications, such as journal articles, dissertations, theses, or monographs. All datasets are required to be in their final state and suitable for public access and distribution. Deposit of sensitive, proprietary, or personally identifiable information is prohibited."
         name:               "Dataset"
+  simple_form:
+    labels:
+      dataset:
+        identifier:       "Alternate Identifier"

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -17,6 +17,7 @@ en:
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"
+        identifier:       "Alternate Identifier"
     hints:
       generic_work:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -24,7 +24,7 @@ en:
           date_uploaded_dtsi: Date Uploaded
           description_tesim: Description
           file_format_tesim: File Format
-          identifier_tesim: Identifier
+          identifier_tesim: Alternate Identifier
           keyword_tesim: Keyword
           language_tesim: Language
           publisher_tesim: Publisher
@@ -39,7 +39,7 @@ en:
           date_uploaded_dtsi: Date Uploaded
           description_tesim: Description
           file_format_tesim: File Format
-          identifier_tesim: Identifier
+          identifier_tesim: Alternate Identifier
           keyword_tesim: Keyword
           language_tesim: Language
           publisher_tesim: Publisher
@@ -74,13 +74,13 @@ en:
         abstract_or_summary: "A short description of the research findings or data using 300 words or fewer."
         publisher: "The name of the organization that published this work."
         date_created: "The date on which the content was created, produced or published. Dates are accepted in the form YYYY-MM-DD, e.g. 1976-07-04."
-        subject: "This field is for controlled subject vocabulary terms. Together, 'Keywords” and “Subjects' help make your work more discoverable online. Use <a href='http://fast.oclc.org/searchfast/''>FAST Subject Headings</a> to link your research with related research. Add one Subject per box."
+        subject: "This field is for controlled subject vocabulary terms. Together, 'Keywords' and 'Subjects' help make your work more discoverable online. Use <a href='http://fast.oclc.org/searchfast/''>FAST Subject Headings</a> to link your research with related research. Add one Subject per box."
         language: "The language in which the paper is written or the data set is documented."
-        identifier: "A unique string of characters such as DOI for a journal article, PubMed ID, PubMed Central ID, or an ISBN for a book. The type of identifier used should be entered before the identifier itself, e.g. “DOI 10.1186/s40169-016-0099-0"
+        identifier: "A unique string of characters such as DOI for a journal article, PubMed ID, PubMed Central ID, or an ISBN for a book. The type of identifier used should be entered before the identifier itself, e.g. 'DOI 10.1186/s40169-016-0099-0'"
         location: "The name of the location where the research was published or otherwise made available."
-        related_url: "A link to the publisher’s webpage of the work or other specific content (such as PDF documents) related to the file. For example, the URL of a research project from which the file was derived or a dataset stored in a data repository."
+        related_url: "A link to the publisher's webpage of the work or other specific content (such as PDF documents) related to the file. For example, the URL of a research project from which the file was derived or a dataset stored in a data repository."
         source: "Enter the journal title or name of the book in which the work was published. Source refers to the origin of the document."
-        resource_type: "Pre-definied categories to describe the type of content being uploaded, such as 'article' or 'presentation'."
+        resource_type: "Pre-defined categories to describe the type of content being uploaded, such as 'article' or 'presentation'."
       dataset:
         contact_information: "Please enter the name and email of the contact person for this dataset."
         related_citation: "Please enter the citation information for any related publication."

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     date_created { ['2021'] }
     subject { ['Just Northwestern Things'] }
 
-    alternate_identifier { ['test-123'] }
     contact_information { ['Test contact information'] }
     related_citation { ['Test citation'] }
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Dataset do
   it { is_expected.to respond_to(:title) }
   it { is_expected.to respond_to(:creator) }
   it { is_expected.to respond_to(:description) }
-  it { is_expected.to respond_to(:alternate_identifier) }
   it { is_expected.to respond_to(:contact_information) }
   it { is_expected.to respond_to(:doi) }
   it { is_expected.to respond_to(:related_citation) }


### PR DESCRIPTION
## Description

- Removes the `alternate_identifier` property from the Dataset work type
- Sets the `identifier` label to `Alternate Identifier` wherever necessary
- Adds the `web-console` gem as a development dependency
- Fixes a handful of yml configuration typos

---

## Screenshots

Edit form:
<img width="971" alt="arch_alt_id_1" src="https://user-images.githubusercontent.com/1395707/123701617-b2cc7500-d827-11eb-9c92-b21f8103a9cd.png">

Show view:
<img width="580" alt="arch_alt_id_2" src="https://user-images.githubusercontent.com/1395707/123701618-b3650b80-d827-11eb-96e9-2ae0711aae81.png">
