### PR TITLE
Configure a custom log formatter to output JSON for improved AWS CloudWatch functionality

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,8 +67,14 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # Custom JSON log formatter
+  config.log_formatter = proc do |severity, datetime, _progname, msg|
+    date_format = datetime.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+    JSON.dump(time: date_format.to_s, severity: severity.ljust(5).to_s, pid: "##{Process.pid}", message: msg) + "\n"
+  end
+
+  # Don't use ANSI color codes in logs
+  config.colorize_logging = false
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'


### PR DESCRIPTION
Attempting to mimic the logging format in the [logger_json](https://hexdocs.pm/logger_json/readme.html#log-format ) Elixir library for consistency across applications. In the screenshot below, I temporarily copied the proc to `development.rb` to demonstrate the output.

![json_log_output](https://user-images.githubusercontent.com/1395707/126372242-d463af29-6807-4141-b647-5081f1a866cd.png)
