### PR TITLE
Return 400 Bad Request when an invalid sort string is specified

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@ class CatalogController < ApplicationController
   include Hydra::Controller::ControllerBehavior
 
   # These before_filters apply the hydra access controls
+  before_action :block_invalid_sort_params, only: :index
   before_action :enforce_show_permissions, only: :show
 
   def self.uploaded_field
@@ -282,6 +283,12 @@ class CatalogController < ApplicationController
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5
+  end
+
+  def block_invalid_sort_params
+    return unless params[:sort]
+    return if blacklight_config.sort_fields.key?(params[:sort])
+    render plain: "Requested illegal sort val: #{params[:sort]}", status: :bad_request
   end
 
   # disable the bookmark control from displaying in gallery view

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -6,5 +6,15 @@ RSpec.describe CatalogController, type: :controller do
       get :index
       expect(response.headers['X-Frame-Options']).to eq 'ALLOWALL'
     end
+
+    it 'allows configured sort order' do
+      get :index, params: { sort: 'date_modified_dtsi desc' }
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns 400 Bad Request on unconfigured sort order' do
+      get :index, params: { sort: 'date_modified_dtsi desc asctests.arachni-scanner.com/rfi.md5.txt' }
+      expect(response.status).to eq(400)
+    end
   end
 end


### PR DESCRIPTION
Fixes nulib/repodev_planning_and_docs#2275

If `CatalogController#index` receives an unknown `sort` parameter, return 400 Bad Request with a terse error message instead of passing the invalid query to Solr.
