### PR TITLE
Increase arch worker database pool size

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -145,8 +145,9 @@ resource "aws_iam_role_policy_attachment" "ecs_exec_command" {
 }
 
 resource "aws_cloudwatch_log_group" "arch_logs" {
-  name = "/ecs/${local.secrets.app_name}"
-  tags = local.tags
+  name                = "/ecs/${local.secrets.app_name}"
+  retention_in_days   = 30
+  tags                = local.tags
 }
 resource "aws_lb_target_group" "arch_target" {
   port                    = 3000

--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -82,6 +82,7 @@ module "arch_task_worker" {
   source           = "./modules/arch_task"
   container_config = local.container_config
   cpu              = 2048
+  db_pool_size     = 20
   memory           = 4096
   container_role   = "worker"
   role_arn         = aws_iam_role.arch_role.arn

--- a/terraform/modules/arch_task/main.tf
+++ b/terraform/modules/arch_task/main.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "this_task_definition" {
       environment = [
         { name = "AWS_REGION",               value = var.container_config.region },
         { name = "CONTAINER_ROLE",           value = var.container_role },
-        { name = "DATABASE_URL",             value = var.container_config.database_url },
+        { name = "DATABASE_URL",             value = "${var.container_config.database_url}?pool=${var.db_pool_size}" },
         { name = "FEDORA_BASE_PATH",         value = var.container_config.fedora_base_path },
         { name = "FEDORA_URL",               value = var.container_config.fedora_url },
         { name = "HONEYBADGER_API_KEY",      value = var.container_config.honeybadger_api_key },

--- a/terraform/modules/arch_task/variables.tf
+++ b/terraform/modules/arch_task/variables.tf
@@ -6,6 +6,11 @@ variable "cpu" {
   type    = number
 }
 
+variable "db_pool_size" {
+  type    = number
+  default = 5
+}
+
 variable "memory" {
   type    = number
 }


### PR DESCRIPTION
Fixes nulib/repodev_planning_and_docs#2288

Increasing Solr's heap size was only one part of the fix. We also needed to increase Arch's database pool size to match the number of worker threads.

Terraform-only change; already applied to both staging and prod.

