### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           bundler-cache: true
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
       - name: Run Static Analysis Tests
         run: bundle exec rubocop
       - name: Setup
@@ -69,7 +69,7 @@ jobs:
   publish:
     needs:
       - test
-    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
+    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
     runs-on: ubuntu-latest
     env:
       AWS_SDK_LOAD_CONFIG: 1
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set DEPLOY_ENV from Branch Name
         run: |
-          if [[ $BRANCH == 'refs/heads/master' ]]; then
+          if [[ $BRANCH == 'refs/heads/main' ]]; then
             echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           else
             echo "DEPLOY_ENV=$(echo $BRANCH | awk -F/ '{print $NF}')" >> $GITHUB_ENV
@@ -92,7 +92,7 @@ jobs:
       - run: echo "Building nulib/arch:${DEPLOY_ENV}"
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1 
+      - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -116,7 +116,7 @@ jobs:
           fetch-depth: 2
       - name: Set DEPLOY_ENV from Branch Name
         run: |
-          if [[ $BRANCH == 'refs/heads/master' ]]; then
+          if [[ $BRANCH == 'refs/heads/main' ]]; then
             echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           else
             echo "DEPLOY_ENV=$(echo $BRANCH | awk -F/ '{print $NF}')" >> $GITHUB_ENV
@@ -144,24 +144,24 @@ jobs:
   tflint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      name: Checkout source code
+      - uses: actions/checkout@v2
+        name: Checkout source code
 
-    - uses: actions/cache@v2
-      name: Cache plugin dir
-      with:
-        path: ~/.tflint.d/plugins
-        key: tflint-${{ hashFiles('.tflint.hcl') }}
+      - uses: actions/cache@v2
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles('.tflint.hcl') }}
 
-    - uses: terraform-linters/setup-tflint@v1
-      name: Setup tflint
+      - uses: terraform-linters/setup-tflint@v1
+        name: Setup tflint
 
-    - name: Show version
-      run: tflint --version
+      - name: Show version
+        run: tflint --version
 
-    - name: Check Terraform Manifests
-      run: |
-        terraform init -backend=false -input=false
-        tflint --init
-        tflint -f compact
-      working-directory: ./terraform
+      - name: Check Terraform Manifests
+        run: |
+          terraform init -backend=false -input=false
+          tflint --init
+          tflint -f compact
+        working-directory: ./terraform

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 node {
   def tag_name = env.BRANCH_NAME.split('/').last()
-  if ( tag_name == "master" ) {
+  if ( tag_name == "main" ) {
     tag_name = "production"
   }
   checkout scm

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ These should match closely with the [Hyrax requirements](https://github.com/proj
 
 - Submit a PR in github to the environment's deploy branch
   - To deploy to staging submit a PR to `deploy/staging`
-  - To deploy to production submit a PR to `master`
+  - To deploy to production submit a PR to `main`

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -16,5 +16,5 @@ rule "aws_resource_missing_tags" {
 rule "terraform_module_pinned_source" {
   enabled             = false
   style               = "flexible"
-  default_branches    = ["master"]
+  default_branches    = ["main"]
 }


### PR DESCRIPTION
Fixes https://github.com/nulib/repodev_planning_and_docs/issues/1884

- rename `master` branch to `main`
- Update deployment scripts


Developers need to run the following in order to update their local git branchs

```
git fetch --prune -a
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```