### PR TITLE
Set Proquest metadata work visiblity after embargo using diss_access_option

### DIFF
--- a/app/lib/proquest/metadata.rb
+++ b/app/lib/proquest/metadata.rb
@@ -30,7 +30,7 @@ class Proquest::Metadata
         rights_statement: ['http://rightsstatements.org/vocab/InC/1.0/'],
         subject: subject,
         title: title,
-        work_visibility_after_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+        work_visibility_after_embargo: convert_diss_access_option,
         work_visibility_during_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
         work_visibility: work_visibility
       }.compact
@@ -79,6 +79,10 @@ class Proquest::Metadata
       # DISS_access_option is typically 'Open access' for embargoed dissertations
       return Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE if embargo_release_date.present?
 
+      convert_diss_access_option
+    end
+
+    def convert_diss_access_option
       case metadata.xpath('//DISS_access_option')&.text&.downcase
       when 'open access'
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

--- a/spec/fixtures/files/proquest/northwestern_0000_DATA_diss_access_option_campus_use_only_with_embargo.xml
+++ b/spec/fixtures/files/proquest/northwestern_0000_DATA_diss_access_option_campus_use_only_with_embargo.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<DISS_submission publishing_option="0" embargo_code="1" third_party_search="Y">
+  <DISS_authorship>
+    <DISS_author type="primary">
+      <DISS_name>
+        <DISS_surname>Last</DISS_surname>
+        <DISS_fname>First</DISS_fname>
+        <DISS_middle>Middle</DISS_middle>
+        <DISS_suffix/>
+      </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>08/10/2018</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>1</DISS_cntry_cd>
+          <DISS_area_code>555</DISS_area_code>
+          <DISS_phone_num>1234567</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1970 Campus Drive</DISS_addrline>
+          <DISS_city>Evanston</DISS_city>
+          <DISS_st>IL</DISS_st>
+          <DISS_pcode>60208</DISS_pcode>
+          <DISS_country>US</DISS_country>
+        </DISS_address>
+        <DISS_email>test@email.edu</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>08/10/2018</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>1</DISS_cntry_cd>
+          <DISS_area_code>555</DISS_area_code>
+          <DISS_phone_num>1234567</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1970 Campus Drive</DISS_addrline>
+          <DISS_city>Evanston</DISS_city>
+          <DISS_st>IL</DISS_st>
+          <DISS_pcode>60208</DISS_pcode>
+          <DISS_country>US</DISS_country>
+        </DISS_address>
+        <DISS_email>test@email.edu</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship/>
+      <DISS_orcid/>
+    </DISS_author>
+  </DISS_authorship>
+  <DISS_description page_count="1" type="doctoral" external_id="http://dissertations.umi.com/northwestern:12345" apply_for_copyright="yes">
+    <DISS_title>Dissertation No Embargo</DISS_title>
+    <DISS_dates>
+      <DISS_comp_date>2019</DISS_comp_date>
+      <DISS_accept_date>01/01/2019</DISS_accept_date>
+    </DISS_dates>
+    <DISS_degree>Ph.D.</DISS_degree>
+    <DISS_institution>
+      <DISS_inst_code>0163</DISS_inst_code>
+      <DISS_inst_name>Northwestern University</DISS_inst_name>
+      <DISS_inst_contact>Example Program</DISS_inst_contact>
+      <DISS_processing_code>D</DISS_processing_code>
+    </DISS_institution>
+    <DISS_advisor>
+      <DISS_name>
+        <DISS_surname>Last</DISS_surname>
+        <DISS_fname>First</DISS_fname>
+        <DISS_middle/>
+      </DISS_name>
+    </DISS_advisor>
+    <DISS_cmte_member>
+      <DISS_name>
+        <DISS_surname>Last</DISS_surname>
+        <DISS_fname>First</DISS_fname>
+        <DISS_middle/>
+        <DISS_suffix/>
+      </DISS_name>
+    </DISS_cmte_member>
+    <DISS_cmte_member>
+      <DISS_name>
+        <DISS_surname>Last</DISS_surname>
+        <DISS_fname>First</DISS_fname>
+        <DISS_middle/>
+        <DISS_suffix/>
+      </DISS_name>
+    </DISS_cmte_member>
+    <DISS_cmte_member>
+      <DISS_name>
+        <DISS_surname>Last</DISS_surname>
+        <DISS_fname>First</DISS_fname>
+        <DISS_middle/>
+        <DISS_suffix/>
+      </DISS_name>
+    </DISS_cmte_member>
+    <DISS_categorization>
+      <DISS_category>
+        <DISS_cat_code>0729</DISS_cat_code>
+        <DISS_cat_desc>Architecture</DISS_cat_desc>
+      </DISS_category>
+      <DISS_category>
+        <DISS_cat_code>0599</DISS_cat_code>
+        <DISS_cat_desc>Quantum physics</DISS_cat_desc>
+      </DISS_category>
+      <DISS_category>
+        <DISS_cat_code>0602</DISS_cat_code>
+        <DISS_cat_desc>Animal behavior</DISS_cat_desc>
+      </DISS_category>
+      <DISS_keyword>keyword1, keyword2</DISS_keyword>
+      <DISS_language>en</DISS_language>
+    </DISS_categorization>
+  </DISS_description>
+  <DISS_content>
+    <DISS_abstract>
+      <DISS_para>Lorem ipsum.</DISS_para>
+      <DISS_para>Dolor sit amet.</DISS_para>
+    </DISS_abstract>
+    <DISS_supp_abstract/>
+    <DISS_binary type="PDF">test_0000.pdf</DISS_binary>
+  </DISS_content>
+  <DISS_restriction/>
+  <DISS_repository>
+    <DISS_version>2017-01-01 12:00:00</DISS_version>
+    <DISS_agreement_decision_date>2018-01-01 12:00:00</DISS_agreement_decision_date>
+    <DISS_acceptance>1</DISS_acceptance>
+    <DISS_delayed_release/>
+    <DISS_access_option>Campus use only</DISS_access_option>
+  </DISS_repository>
+</DISS_submission>

--- a/spec/lib/proquest/metadata_spec.rb
+++ b/spec/lib/proquest/metadata_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe Proquest::Metadata do
         metadata, _file_list = record.proquest_metadata
         expect(metadata[:file_set_visibility]).to eq 'restricted'
         expect(metadata[:work_visibility]).to eq 'restricted'
+        expect(metadata[:work_visibility_after_embargo]).to eq 'open'
+      end
+    end
+
+    context 'DISS_access_option campus use only with an embargo' do
+      let(:xml) { "#{file_fixture_path}/proquest/northwestern_0000_DATA_diss_access_option_campus_use_only_with_embargo.xml" }
+      let(:record) { described_class.new(xml, today) }
+
+      it 'sets work visibility and file set visibility to private' do
+        metadata, _file_list = record.proquest_metadata
+        expect(metadata[:file_set_visibility]).to eq 'restricted'
+        expect(metadata[:work_visibility]).to eq 'restricted'
+        expect(metadata[:work_visibility_after_embargo]).to eq 'authenticated'
       end
     end
 


### PR DESCRIPTION
Refs #790

Use the `diss_access_option` to set the work_visibility_after_embargo value, e.g.:

| diss_access_option | work_visibility_after_embargo |
| --- | --- |
| "Open" | `open` |
| "Campus use only" | `authenticated` |
| default / no value | `restricted` |