### PR TITLE
Terraforms load balancer configuration idle_timeout set to 1 hour in order to prevent errors uploading large files

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "arch_role_permissions" {
     ]
     resources = ["*"]
   }
-  
+
   statement {
     sid    = "sns"
     effect = "Allow"
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "arch_role_permissions" {
   }
 
   statement {
-    sid = "email"
+    sid    = "email"
     effect = "Allow"
     actions = [
       "ses:Send*"
@@ -87,11 +87,11 @@ data "aws_iam_policy_document" "arch_role_permissions" {
 }
 
 resource "aws_security_group" "arch_load_balancer" {
-  name          = "${var.app_name}-lb"
-  description   = "arch Load Balancer Security Group"
-  vpc_id        = module.core.outputs.vpc.id
-  tags          = local.tags
-  
+  name        = "${var.app_name}-lb"
+  description = "arch Load Balancer Security Group"
+  vpc_id      = module.core.outputs.vpc.id
+  tags        = local.tags
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -100,19 +100,19 @@ resource "aws_security_group" "arch_load_balancer" {
   }
 
   ingress {
-    description   = "HTTP in"
-    from_port     = 80
-    to_port       = 80
-    protocol      = "tcp"
-    cidr_blocks   = ["0.0.0.0/0"]
+    description = "HTTP in"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    description   = "HTTPS in"
-    from_port     = 443
-    to_port       = 443
-    protocol      = "tcp"
-    cidr_blocks   = ["0.0.0.0/0"]
+    description = "HTTPS in"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
@@ -154,17 +154,17 @@ resource "aws_iam_role_policy_attachment" "ecs_exec_command" {
 }
 
 resource "aws_cloudwatch_log_group" "arch_logs" {
-  name                = "/ecs/${var.app_name}"
-  retention_in_days   = 30
-  tags                = local.tags
+  name              = "/ecs/${var.app_name}"
+  retention_in_days = 30
+  tags              = local.tags
 }
 resource "aws_lb_target_group" "arch_target" {
-  port                    = 3000
-  deregistration_delay    = 30
-  target_type             = "ip"
-  protocol                = "HTTP"
-  vpc_id                  = module.core.outputs.vpc.id
-  tags                    = local.tags
+  port                 = 3000
+  deregistration_delay = 30
+  target_type          = "ip"
+  protocol             = "HTTP"
+  vpc_id               = module.core.outputs.vpc.id
+  tags                 = local.tags
 
   stickiness {
     enabled = false
@@ -176,10 +176,11 @@ resource "aws_lb" "arch_load_balancer" {
   name               = "${var.app_name}-lb"
   internal           = false
   load_balancer_type = "application"
+  idle_timeout       = 3600
 
   subnets         = module.core.outputs.vpc.public_subnets.ids
   security_groups = [aws_security_group.arch_load_balancer.id]
-  tags    = local.tags
+  tags            = local.tags
 }
 
 resource "aws_lb_listener" "arch_lb_listener_http" {


### PR DESCRIPTION
Already applied in both staging and production environments.