### PR TITLE
Mount arch-working/tmp on /tmp in Arch containers

### DIFF
--- a/terraform/modules/arch_task/main.tf
+++ b/terraform/modules/arch_task/main.tf
@@ -83,6 +83,10 @@ resource "aws_ecs_task_definition" "this_task_definition" {
         { 
           "sourceVolume": "arch-working",
           "containerPath": "/var/arch-working"
+        },
+        {
+          "sourceVolume": "arch-temp",
+          "containerPath": "/tmp"
         }
       ]
     }
@@ -99,6 +103,14 @@ resource "aws_ecs_task_definition" "this_task_definition" {
     name = "arch-working"
     efs_volume_configuration {
       file_system_id = var.container_config.working_volume_id
+    }
+  }
+
+  volume {
+    name = "arch-temp"
+    efs_volume_configuration {
+      file_system_id = var.container_config.working_volume_id
+      root_directory = "/tmp"
     }
   }
 


### PR DESCRIPTION
Fixes #2979

Update Terraform to mount EFS temp space in both webapp and working containers

Already applied to both staging and prod
